### PR TITLE
Correctly label x86/x86_64 specific code

### DIFF
--- a/src/ioctls/mod.rs
+++ b/src/ioctls/mod.rs
@@ -1,4 +1,6 @@
-use kvm_bindings::{kvm_cpuid2, kvm_cpuid_entry2, kvm_run};
+use kvm_bindings::kvm_run;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use kvm_bindings::{kvm_cpuid2, kvm_cpuid_entry2};
 use std::io;
 use std::mem::size_of;
 use std::os::unix::io::AsRawFd;

--- a/src/ioctls/system.rs
+++ b/src/ioctls/system.rs
@@ -9,7 +9,9 @@ use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use cap::Cap;
 use ioctls::vec_with_array_field;
 use ioctls::vm::{new_vmfd, VmFd};
-use ioctls::{CpuId, Result};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use ioctls::CpuId;
+use ioctls::Result;
 use kvm_ioctls::*;
 use sys_ioctl::*;
 

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -4,7 +4,9 @@ use std::fs::File;
 use std::io;
 use std::os::unix::io::{AsRawFd, RawFd};
 
-use ioctls::{CpuId, KvmRunWrapper, Result};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use ioctls::CpuId;
+use ioctls::{KvmRunWrapper, Result};
 use kvm_ioctls::*;
 use sys_ioctl::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,9 @@ pub use cap::Cap;
 pub use ioctls::system::Kvm;
 pub use ioctls::vcpu::{VcpuExit, VcpuFd};
 pub use ioctls::vm::VmFd;
-pub use ioctls::{CpuId, KvmRunWrapper, Result};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use ioctls::CpuId;
+use ioctls::{KvmRunWrapper, Result};
 
 /// Maximum number of CPUID entries that can be returned by a call to KVM ioctls.
 ///


### PR DESCRIPTION
Test it with `cargo build --target aarch64-unknown-linux-musl`
