### PR TITLE
kvm system ioctls: updated public functions docs

### DIFF
--- a/src/cap.rs
+++ b/src/cap.rs
@@ -7,9 +7,13 @@
 
 use kvm_bindings::*;
 
-/// Enumeration of the extension capability list that KVM exposes.
+/// Capabilities exposed by KVM.
 ///
-/// For details check the
+/// The capabilities list can be used in conjunction with
+/// [Kvm::check_extension()](struct.Kvm.html#method.check_extension) to check if a particular
+/// capability is available.
+///
+/// The list of capabilities is based on the the KVM_CAP_* defines from the
 /// [Linux KVM header](https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/kvm.h).
 ///
 #[derive(Clone, Copy, Debug)]

--- a/src/ioctls/mod.rs
+++ b/src/ioctls/mod.rs
@@ -61,11 +61,12 @@ fn vec_with_array_field<T: Default, F>(count: usize) -> Vec<T> {
     vec_with_size_in_bytes(vec_size_bytes)
 }
 
-/// Wrapper for `kvm_cpuid2` which has a zero length array at the end.
-/// Hides the zero length array behind a bounds check.
+/// Wrapper over the `kvm_cpuid2` structure.
+///
+/// The structure has a zero length array at the end, hidden behind bounds check.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub struct CpuId {
-    /// Wrapper over `kvm_cpuid2` from which we only use the first element.
+    // Wrapper over `kvm_cpuid2` from which we only use the first element.
     kvm_cpuid: Vec<kvm_cpuid2>,
     // Number of `kvm_cpuid_entry2` structs at the end of kvm_cpuid2.
     allocated_len: usize,
@@ -110,7 +111,7 @@ impl PartialEq for CpuId {
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 impl CpuId {
-    /// Creates a new `CpuId` structure that can contain at most `array_len` KVM CPUID entries.
+    /// Creates a new `CpuId` structure that contains at most `array_len` KVM CPUID entries.
     ///
     /// # Arguments
     ///
@@ -119,7 +120,6 @@ impl CpuId {
     /// # Example
     ///
     /// ```
-    /// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     /// use kvm_ioctls::CpuId;
     /// let cpu_id = CpuId::new(32);
     /// ```
@@ -133,7 +133,15 @@ impl CpuId {
         }
     }
 
-    /// Get the mutable entries slice so they can be modified before passing to the VCPU.
+    /// Returns the mutable entries slice so they can be modified before passing to the VCPU.
+    ///
+    /// # Example
+    /// ```rust
+    /// use kvm_ioctls::{CpuId, Kvm, MAX_KVM_CPUID_ENTRIES};
+    /// let kvm = Kvm::new().unwrap();
+    /// let mut cpuid = kvm.get_supported_cpuid(MAX_KVM_CPUID_ENTRIES).unwrap();
+    /// let cpuid_entries = cpuid.mut_entries_slice();
+    /// ```
     ///
     pub fn mut_entries_slice(&mut self) -> &mut [kvm_cpuid_entry2] {
         // Mapping the unsized array to a slice is unsafe because the length isn't known.  Using
@@ -158,7 +166,7 @@ impl CpuId {
     }
 }
 
-/// A safe wrapper over the `kvm_run` struct.
+/// Safe wrapper over the `kvm_run` struct.
 ///
 /// The wrapper is needed for sending the pointer to `kvm_run` between
 /// threads as raw pointers do not implement `Send` and `Sync`.

--- a/src/ioctls/system.rs
+++ b/src/ioctls/system.rs
@@ -300,7 +300,7 @@ mod tests {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
 
-        assert_eq!(vm.get_run_size(), kvm.get_vcpu_mmap_size().unwrap());
+        assert_eq!(vm.run_size(), kvm.get_vcpu_mmap_size().unwrap());
     }
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/src/ioctls/system.rs
+++ b/src/ioctls/system.rs
@@ -22,15 +22,20 @@ use ioctls::Result;
 use kvm_ioctls::*;
 use sys_ioctl::*;
 
-/// A wrapper over the `/dev/kvm` file.
-///
-/// The handle is used to issue KVM system ioctls.
+/// Wrapper over KVM system ioctls.
 pub struct Kvm {
     kvm: File,
 }
 
 impl Kvm {
-    /// Opens `/dev/kvm/` and returns a `Kvm` object on success.
+    /// Opens `/dev/kvm` and returns a `Kvm` object on success.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use kvm_ioctls::Kvm;
+    /// let kvm = Kvm::new().unwrap();
+    /// ```
     ///
     #[allow(clippy::new_ret_no_self)]
     pub fn new() -> Result<Self> {
@@ -42,6 +47,8 @@ impl Kvm {
 
     /// Creates a new Kvm object assuming `fd` represents an existing open file descriptor
     /// associated with `/dev/kvm`.
+    ///
+    /// For usage examples check [open_with_cloexec()](struct.Kvm.html#method.open_with_cloexec).
     ///
     /// # Arguments
     ///
@@ -55,9 +62,24 @@ impl Kvm {
 
     /// Opens `/dev/kvm` and returns the fd number on success.
     ///
+    /// One usecase for this method is opening `/dev/kvm` before exec-ing into a
+    /// process with seccomp filters enabled that blacklist the `sys_open` syscall.
+    /// For this usecase `open_with_cloexec` must be called with the `close_on_exec`
+    /// parameter set to false.
+    ///
     /// # Arguments
     ///
     /// * `close_on_exec`: If true opens `/dev/kvm` using the `O_CLOEXEC` flag.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use kvm_ioctls::Kvm;
+    /// let kvm_fd = Kvm::open_with_cloexec(false).unwrap();
+    /// // The `kvm_fd` can now be passed to another process where we can use
+    /// // `new_with_fd_number` for creating a `Kvm` object:
+    /// let kvm = unsafe { Kvm::new_with_fd_number(kvm_fd) };
+    /// ```
     ///
     pub fn open_with_cloexec(close_on_exec: bool) -> Result<RawFd> {
         let open_flags = O_RDWR | if close_on_exec { O_CLOEXEC } else { 0 };
@@ -73,6 +95,15 @@ impl Kvm {
     /// Returns the KVM API version.
     ///
     /// See the documentation for `KVM_GET_API_VERSION`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use kvm_ioctls::Kvm;
+    /// let kvm = Kvm::new().unwrap();
+    /// assert_eq!(kvm.get_api_version(), 12);
+    /// ```
+    ///
     pub fn get_api_version(&self) -> i32 {
         // Safe because we know that our file is a KVM fd and that the request is one of the ones
         // defined by kernel.
@@ -80,8 +111,8 @@ impl Kvm {
     }
 
     /// Wrapper over `KVM_CHECK_EXTENSION`.
-    /// Returns 0 if the capability is not available and a positive integer otherwise.
     ///
+    /// Returns 0 if the capability is not available and a positive integer otherwise.
     fn check_extension_int(&self, c: Cap) -> i32 {
         // Safe because we know that our file is a KVM fd and that the extension is one of the ones
         // defined by kernel.
@@ -90,12 +121,23 @@ impl Kvm {
 
     /// Checks if a particular `Cap` is available.
     ///
+    /// Returns true if the capability is supported and false otherwise.
     /// See the documentation for `KVM_CHECK_EXTENSION`.
-    /// Returns "0 if the capability is unsupported or a positive integer otherwise.
     ///
     /// # Arguments
     ///
-    /// * `c` - KVM capability.
+    /// * `c` - KVM capability to check.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use kvm_ioctls::Kvm;
+    /// use kvm_ioctls::Cap;
+    ///
+    /// let kvm = Kvm::new().unwrap();
+    /// // Check if `KVM_CAP_USER_MEMORY` is supported.
+    /// assert!(kvm.check_extension(Cap::UserMemory));
+    /// ```
     ///
     pub fn check_extension(&self, c: Cap) -> bool {
         self.check_extension_int(c) > 0
@@ -104,6 +146,14 @@ impl Kvm {
     ///  Returns the size of the memory mapping required to use the vcpu's `kvm_run` structure.
     ///
     /// See the documentation for `KVM_GET_VCPU_MMAP_SIZE`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use kvm_ioctls::Kvm;
+    /// let kvm = Kvm::new().unwrap();
+    /// assert!(kvm.get_vcpu_mmap_size().unwrap() > 0);
+    /// ```
     ///
     pub fn get_vcpu_mmap_size(&self) -> Result<usize> {
         // Safe because we know that our file is a KVM fd and we verify the return result.
@@ -119,6 +169,16 @@ impl Kvm {
     ///
     /// See the documentation for `KVM_CAP_NR_VCPUS`.
     /// Default to 4 when `KVM_CAP_NR_VCPUS` is not implemented.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use kvm_ioctls::Kvm;
+    /// let kvm = Kvm::new().unwrap();
+    /// // We expect the number of vCPUs to be > 0 as per KVM API documentation.
+    /// assert!(kvm.get_nr_vcpus() > 0);
+    /// ```
+    ///
     pub fn get_nr_vcpus(&self) -> usize {
         let x = self.check_extension_int(Cap::NrVcpus);
         if x > 0 {
@@ -128,12 +188,20 @@ impl Kvm {
         }
     }
 
-    /// Gets the maximum allowed memory slots per VM.
+    /// Returns the maximum allowed memory slots per VM.
     ///
     /// KVM reports the number of available memory slots (`KVM_CAP_NR_MEMSLOTS`)
     /// using the extension interface.  Both x86 and s390 implement this, ARM
     /// and powerpc do not yet enable it.
     /// Default to 32 when `KVM_CAP_NR_MEMSLOTS` is not implemented.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use kvm_ioctls::Kvm;
+    /// let kvm = Kvm::new().unwrap();
+    /// assert!(kvm.get_nr_memslots() > 0);
+    /// ```
     ///
     pub fn get_nr_memslots(&self) -> usize {
         let x = self.check_extension_int(Cap::NrMemslots);
@@ -147,7 +215,16 @@ impl Kvm {
     /// Gets the recommended maximum number of VCPUs per VM.
     ///
     /// See the documentation for `KVM_CAP_MAX_VCPUS`.
-    /// Default to `KVM_CAP_NR_VCPUS` when `KVM_CAP_MAX_VCPUS` is not implemented.
+    /// Returns [get_nr_vcpus()](struct.Kvm.html#method.get_nr_vcpus) when
+    /// `KVM_CAP_MAX_VCPUS` is not implemented.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use kvm_ioctls::Kvm;
+    /// let kvm = Kvm::new().unwrap();
+    /// assert!(kvm.get_max_vcpus() > 0);
+    /// ```
     ///
     pub fn get_max_vcpus(&self) -> usize {
         match self.check_extension_int(Cap::MaxVcpus) {
@@ -175,12 +252,23 @@ impl Kvm {
 
     /// X86 specific call to get the system emulated CPUID values.
     ///
-    /// See the documentation for KVM_GET_EMULATED_CPUID.
+    /// See the documentation for `KVM_GET_EMULATED_CPUID`.
     ///
     /// # Arguments
     ///
     /// * `max_entries_count` - Maximum number of CPUID entries. This function can return less than
     ///                         this when the hardware does not support so many CPUID entries.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use kvm_ioctls::{Kvm, MAX_KVM_CPUID_ENTRIES};
+    ///
+    /// let kvm = Kvm::new().unwrap();
+    /// let mut cpuid = kvm.get_emulated_cpuid(MAX_KVM_CPUID_ENTRIES).unwrap();
+    /// let cpuid_entries = cpuid.mut_entries_slice();
+    /// assert!(cpuid_entries.len() <= MAX_KVM_CPUID_ENTRIES);
+    /// ```
     ///
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn get_emulated_cpuid(&self, max_entries_count: usize) -> Result<CpuId> {
@@ -189,12 +277,23 @@ impl Kvm {
 
     /// X86 specific call to get the system supported CPUID values.
     ///
-    /// See the documentation for KVM_GET_SUPPORTED_CPUID.
+    /// See the documentation for `KVM_GET_SUPPORTED_CPUID`.
     ///
     /// # Arguments
     ///
     /// * `max_entries_count` - Maximum number of CPUID entries. This function can return less than
     ///                         this when the hardware does not support so many CPUID entries.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use kvm_ioctls::{Kvm, MAX_KVM_CPUID_ENTRIES};
+    ///
+    /// let kvm = Kvm::new().unwrap();
+    /// let mut cpuid = kvm.get_emulated_cpuid(MAX_KVM_CPUID_ENTRIES).unwrap();
+    /// let cpuid_entries = cpuid.mut_entries_slice();
+    /// assert!(cpuid_entries.len() <= MAX_KVM_CPUID_ENTRIES);
+    /// ```
     ///
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn get_supported_cpuid(&self, max_entries_count: usize) -> Result<CpuId> {
@@ -203,8 +302,16 @@ impl Kvm {
 
     /// X86 specific call to get list of supported MSRS
     ///
-    /// See the documentation for KVM_GET_MSR_INDEX_LIST.
+    /// See the documentation for `KVM_GET_MSR_INDEX_LIST`.
     ///
+    /// # Example
+    ///
+    /// ```
+    /// use kvm_ioctls::{Kvm, MAX_KVM_CPUID_ENTRIES};
+    ///
+    /// let kvm = Kvm::new().unwrap();
+    /// let msr_index_list = kvm.get_msr_index_list().unwrap();
+    /// ```
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn get_msr_index_list(&self) -> Result<Vec<u32>> {
         const MAX_KVM_MSR_ENTRIES: usize = 256;
@@ -241,6 +348,16 @@ impl Kvm {
     /// See the documentation for `KVM_CREATE_VM`.
     /// A call to this function will also initialize the size of the vcpu mmap area using the
     /// `KVM_GET_VCPU_MMAP_SIZE` ioctl.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use kvm_ioctls::Kvm;
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// // Check that the VM mmap size is the same reported by `KVM_GET_VCPU_MMAP_SIZE`.
+    /// assert!(vm.run_size() == kvm.get_vcpu_mmap_size().unwrap());
+    /// ```
     ///
     pub fn create_vm(&self) -> Result<VmFd> {
         // Safe because we know `self.kvm` is a real KVM fd as this module is the only one that

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -17,8 +17,11 @@ use ioctls::{KvmRunWrapper, Result};
 use kvm_ioctls::*;
 use sys_ioctl::*;
 
-/// Reasons for vCPU exits. The exit reasons are mapped to the `KVM_EXIT_*` defines
-/// from `include/uapi/linux/kvm.h`.
+/// Reasons for vCPU exits.
+///
+/// The exit reasons are mapped to the `KVM_EXIT_*` defines in the
+/// [Linux KVM header](https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/kvm.h).
+///
 #[derive(Debug)]
 pub enum VcpuExit<'a> {
     /// An out port instruction was run on the given port with the given data.
@@ -89,14 +92,30 @@ pub enum VcpuExit<'a> {
     Hyperv,
 }
 
-/// A wrapper around creating and using a kvm related vCPU file descriptor.
+/// Wrapper over KVM vCPU ioctls.
 pub struct VcpuFd {
     vcpu: File,
     kvm_run_ptr: KvmRunWrapper,
 }
 
 impl VcpuFd {
-    /// Gets the vCPU registers using the `KVM_GET_REGS` ioctl.
+    /// Returns the vCPU general purpose registers.
+    ///
+    /// The registers are returned in a `kvm_regs` structure as defined in the
+    /// [KVM API documentation](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt).
+    /// See documentation for `KVM_GET_REGS`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// let vcpu = vm.create_vcpu(0).unwrap();
+    /// #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
+    /// let regs = vcpu.get_regs().unwrap();
+    /// ```
     ///
     #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     pub fn get_regs(&self) -> Result<kvm_regs> {
@@ -110,11 +129,30 @@ impl VcpuFd {
         Ok(regs)
     }
 
-    /// Sets the vCPU registers using `KVM_SET_REGS` ioctl.
+    /// Sets the vCPU general purpose registers using the `KVM_SET_REGS` ioctl.
     ///
     /// # Arguments
     ///
-    /// * `regs` - Registers being set.
+    /// * `regs` - general purpose registers. For details check the `kvm_regs` structure in the
+    ///             [KVM API doc](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// let vcpu = vm.create_vcpu(0).unwrap();
+    ///
+    /// #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))] {
+    ///     // Get the current vCPU registers.
+    ///     let mut regs = vcpu.get_regs().unwrap();
+    ///     // Set a new value for the Instruction Pointer.
+    ///     regs.rip = 0x100;
+    ///     vcpu.set_regs(&regs).unwrap();
+    /// }
+    /// ```
     ///
     #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     pub fn set_regs(&self, regs: &kvm_regs) -> Result<()> {
@@ -127,7 +165,23 @@ impl VcpuFd {
         Ok(())
     }
 
-    /// Gets the vCPU special registers using `KVM_GET_SREGS` ioctl.
+    /// Returns the vCPU special registers.
+    ///
+    /// The registers are returned in a `kvm_sregs` structure as defined in the
+    /// [KVM API documentation](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt).
+    /// See documentation for `KVM_GET_SREGS`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// let vcpu = vm.create_vcpu(0).unwrap();
+    /// #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
+    /// let sregs = vcpu.get_sregs().unwrap();
+    /// ```
     ///
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn get_sregs(&self) -> Result<kvm_sregs> {
@@ -142,11 +196,29 @@ impl VcpuFd {
         Ok(regs)
     }
 
-    /// Sets the vCPU special registers using `KVM_SET_SREGS` ioctl.
+    /// Sets the vCPU special registers using the `KVM_SET_SREGS` ioctl.
     ///
     /// # Arguments
     ///
-    /// * `sregs` - Special registers to be set.
+    /// * `sregs` - Special registers. For details check the `kvm_sregs` structure in the
+    ///             [KVM API doc](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// let vcpu = vm.create_vcpu(0).unwrap();
+    /// #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))] {
+    ///     let mut sregs = vcpu.get_sregs().unwrap();
+    ///     // Update the code segment (cs).
+    ///     sregs.cs.base = 0;
+    ///     sregs.cs.selector = 0;
+    ///     vcpu.set_sregs(&sregs).unwrap();
+    /// }
+    /// ```
     ///
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn set_sregs(&self, sregs: &kvm_sregs) -> Result<()> {
@@ -159,9 +231,23 @@ impl VcpuFd {
         Ok(())
     }
 
-    /// X86 specific call that gets the FPU-related structure.
+    /// Returns the floating point state (FPU) from the vCPU.
     ///
+    /// The state is returned in a `kvm_fpu` structure as defined in the
+    /// [KVM API doc](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt).
     /// See the documentation for `KVM_GET_FPU`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// let vcpu = vm.create_vcpu(0).unwrap();
+    /// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    /// let fpu = vcpu.get_fpu().unwrap();
+    /// ```
     ///
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn get_fpu(&self) -> Result<kvm_fpu> {
@@ -177,13 +263,32 @@ impl VcpuFd {
         Ok(fpu)
     }
 
-    /// X86 specific call to setup the FPU.
-    ///
-    /// See the documentation for `KVM_SET_FPU`.
+    /// Set the floating point state (FPU) of a vCPU using the `KVM_SET_FPU` ioct.
     ///
     /// # Arguments
     ///
-    /// * `fpu` - FPU configurations struct.
+    /// * `fpu` - FPU configuration. For details check the `kvm_fpu` structure in the
+    ///           [KVM API doc](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// # extern crate kvm_bindings;
+    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// # use kvm_bindings::kvm_fpu;
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// let vcpu = vm.create_vcpu(0).unwrap();
+    /// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
+    ///     let KVM_FPU_CWD: u16 = 0x37f;
+    ///     let fpu = kvm_fpu {
+    ///         fcw: KVM_FPU_CWD,
+    ///         ..Default::default()
+    ///     };
+    ///     vcpu.set_fpu(&fpu).unwrap();
+    /// }
+    /// ```
     ///
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn set_fpu(&self, fpu: &kvm_fpu) -> Result<()> {
@@ -205,10 +310,37 @@ impl VcpuFd {
     ///
     /// * `cpuid` - CPUID registers.
     ///
+    /// # Example
+    ///
+    ///  ```rust
+    /// # extern crate kvm_ioctls;
+    /// # extern crate kvm_bindings;
+    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd, MAX_KVM_CPUID_ENTRIES};
+    /// # use kvm_bindings::kvm_fpu;
+    /// let kvm = Kvm::new().unwrap();
+    /// let mut kvm_cpuid = kvm.get_supported_cpuid(MAX_KVM_CPUID_ENTRIES).unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// let vcpu = vm.create_vcpu(0).unwrap();
+    ///
+    /// // Update the CPUID entries to disable the EPB feature.
+    /// const ECX_EPB_SHIFT: u32 = 3;
+    /// {
+    ///     let entries = kvm_cpuid.mut_entries_slice();
+    ///     for entry in entries.iter_mut() {
+    ///         match entry.function {
+    ///             6 => entry.ecx &= !(1 << ECX_EPB_SHIFT),
+    ///             _ => (),
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// vcpu.set_cpuid2(&kvm_cpuid);
+    /// ```
+    ///
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn set_cpuid2(&self, cpuid: &CpuId) -> Result<()> {
         let ret = unsafe {
-            // Here we trust the kernel not to read past the end of the kvm_msrs struct.
+            // Here we trust the kernel not to read past the end of the kvm_cpuid2 struct.
             ioctl_with_ptr(self, KVM_SET_CPUID2(), cpuid.as_ptr())
         };
         if ret < 0 {
@@ -217,10 +349,24 @@ impl VcpuFd {
         Ok(())
     }
 
-    /// X86 specific call to get the state of the LAPIC (Local Advanced Programmable Interrupt
-    /// Controller).
+    /// Returns the state of the LAPIC (Local Advanced Programmable Interrupt Controller).
     ///
+    /// The state is returned in a `kvm_lapic_state` structure as defined in the
+    /// [KVM API doc](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt).
     /// See the documentation for `KVM_GET_LAPIC`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// // For `get_lapic` to work, you first need to create a IRQ chip before creating the vCPU.
+    /// vm.create_irq_chip().unwrap();
+    /// let vcpu = vm.create_vcpu(0).unwrap();
+    /// let lapic = vcpu.get_lapic().unwrap();
+    /// ```
     ///
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn get_lapic(&self) -> Result<kvm_lapic_state> {
@@ -237,14 +383,38 @@ impl VcpuFd {
         Ok(klapic)
     }
 
-    /// X86 specific call to set the state of the LAPIC (Local Advanced Programmable Interrupt
-    /// Controller).
+    /// Sets the state of the LAPIC (Local Advanced Programmable Interrupt Controller).
     ///
     /// See the documentation for `KVM_SET_LAPIC`.
     ///
     /// # Arguments
     ///
-    /// * `klapic` - LAPIC state registers.
+    /// * `klapic` - LAPIC state. For details check the `kvm_lapic_state` structure in the
+    ///             [KVM API doc](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt).
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// use std::io::Write;
+    ///
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// // For `get_lapic` to work, you first need to create a IRQ chip before creating the vCPU.
+    /// vm.create_irq_chip().unwrap();
+    /// let vcpu = vm.create_vcpu(0).unwrap();
+    /// let mut lapic = vcpu.get_lapic().unwrap();
+    ///
+    /// // Write to APIC_ICR offset the value 2.
+    /// let apic_icr_offset = 0x300;
+    /// let write_value: &[u8] = &[2, 0, 0, 0];
+    /// let mut apic_icr_slice =
+    ///     unsafe { &mut *(&mut lapic.regs[apic_icr_offset..] as *mut [i8] as *mut [u8]) };
+    /// apic_icr_slice.write(write_value).unwrap();
+    ///
+    /// // Update the value of LAPIC.
+    ///vcpu.set_lapic(&lapic).unwrap();
+    /// ```
     ///
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn set_lapic(&self, klapic: &kvm_lapic_state) -> Result<()> {
@@ -258,14 +428,30 @@ impl VcpuFd {
         Ok(())
     }
 
-    /// X86 specific call to read model-specific registers for this vCPU.
+    /// Returns the model-specific registers (MSR) for this vCPU.
     ///
     /// It emulates `KVM_GET_MSRS` ioctl's behavior by returning the number of MSRs
     /// successfully read upon success or the last error number in case of failure.
+    /// The MSRs are returned in the `msr` method argument.
     ///
     /// # Arguments
     ///
-    /// * `msrs`  - MSRs to be read.
+    /// * `msrs`  - MSRs (input/output). For details check the `kvm_msrs` structure in the
+    ///             [KVM API doc](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// # extern crate kvm_bindings;
+    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// # use kvm_bindings::kvm_msrs;
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// let vcpu = vm.create_vcpu(0).unwrap();
+    /// let mut msrs = kvm_msrs::default();
+    /// vcpu.get_msrs(&mut msrs).unwrap();
+    /// ```
     ///
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn get_msrs(&self, msrs: &mut kvm_msrs) -> Result<(i32)> {
@@ -279,13 +465,45 @@ impl VcpuFd {
         Ok(ret)
     }
 
-    /// X86 specific call to setup the MSRS.
+    /// Setup the model-specific registers (MSR) for this vCPU.
     ///
     /// See the documentation for `KVM_SET_MSRS`.
     ///
     /// # Arguments
     ///
-    /// * `kvm_msrs` - MSRs to be written.
+    /// * `msrs` - MSRs. For details check the `kvm_msrs` structure in the
+    ///            [KVM API doc](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt).
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// # extern crate kvm_bindings;
+    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// # use kvm_bindings::{kvm_msrs, kvm_msr_entry};
+    /// # use std::mem;
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// let vcpu = vm.create_vcpu(0).unwrap();
+    /// let mut msrs = kvm_msrs::default();
+    /// vcpu.get_msrs(&mut msrs).unwrap();
+    ///
+    /// let msrs_entries = {
+    ///     kvm_msr_entry {
+    ///         index: 0x0000_0174,
+    ///         ..Default::default()
+    ///     }
+    /// };
+    ///
+    /// // Create a vector large enough to hold the MSR entry defined above in
+    /// // a `kvm_msrs`structure.
+    /// let msrs_vec: Vec<u8> =
+    ///     Vec::with_capacity(mem::size_of::<kvm_msrs>() + mem::size_of::<kvm_msr_entry>());
+    /// let mut msrs: &mut kvm_msrs = unsafe {
+    ///     &mut *(msrs_vec.as_ptr() as *mut kvm_msrs)
+    /// };
+    /// msrs.nmsrs = 1;
+    /// vcpu.set_msrs(msrs).unwrap();
+    /// ```
     ///
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn set_msrs(&self, msrs: &kvm_msrs) -> Result<()> {
@@ -303,11 +521,29 @@ impl VcpuFd {
     /// Sets the type of CPU to be exposed to the guest and optional features.
     ///
     /// This initializes an ARM vCPU to the specified type with the specified features
-    /// and resets the values of all of its registers to defaults.
+    /// and resets the values of all of its registers to defaults. See the documentation for
+    /// `KVM_ARM_VCPU_INIT`.
     ///
     /// # Arguments
     ///
     /// * `kvi` - information about preferred CPU target type and recommended features for it.
+    ///           For details check the `kvm_vcpu_init` structure in the
+    ///           [KVM API doc](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt).
+    ///
+    /// # Example
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// # extern crate kvm_bindings;
+    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// use kvm_bindings::kvm_vcpu_init;
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// let vcpu = vm.create_vcpu(0).unwrap();
+    ///
+    /// let mut kvi = kvm_vcpu_init::default();
+    /// vm.get_preferred_target(&mut kvi).unwrap();
+    /// vcpu.vcpu_init(&kvi).unwrap();
+    /// ```
     ///
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     pub fn vcpu_init(&self, kvi: &kvm_vcpu_init) -> Result<()> {
@@ -347,6 +583,81 @@ impl VcpuFd {
     }
 
     /// Triggers the running of the current virtual CPU returning an exit reason.
+    ///
+    /// See documentation for `KVM_RUN`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// # extern crate kvm_bindings;
+    /// # use std::io::Write;
+    /// # use std::ptr::null_mut;
+    /// # use std::slice;
+    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd, VcpuExit};
+    /// # use kvm_bindings::{kvm_userspace_memory_region, KVM_MEM_LOG_DIRTY_PAGES};
+    /// # let kvm = Kvm::new().unwrap();
+    /// # let vm = kvm.create_vm().unwrap();
+    /// // This is a dummy example for running on x86 based on https://lwn.net/Articles/658511/.
+    /// #[cfg(target_arch = "x86_64")] {
+    ///     let mem_size = 0x4000;
+    ///     let guest_addr: u64 = 0x1000;
+    ///     let load_addr: *mut u8 = unsafe {
+    ///         libc::mmap(
+    ///             null_mut(),
+    ///             mem_size,
+    ///             libc::PROT_READ | libc::PROT_WRITE,
+    ///             libc::MAP_ANONYMOUS | libc::MAP_SHARED | libc::MAP_NORESERVE,
+    ///             -1,
+    ///             0,
+    ///         ) as *mut u8
+    ///     };
+    ///
+    ///     let mem_region = kvm_userspace_memory_region {
+    ///         slot: 0,
+    ///         guest_phys_addr: guest_addr,
+    ///         memory_size: mem_size as u64,
+    ///         userspace_addr: load_addr as u64,
+    ///         flags: 0,
+    ///     };
+    ///     vm.set_user_memory_region(mem_region).unwrap();
+    ///
+    ///     // Dummy x86 code that just calls halt.
+    ///     let x86_code = [
+    ///             0xf4,             /* hlt */
+    ///     ];
+    ///
+    ///     // Write the code in the guest memory. This will generate a dirty page.
+    ///     unsafe {
+    ///         let mut slice = slice::from_raw_parts_mut(load_addr, mem_size);
+    ///         slice.write(&x86_code).unwrap();
+    ///     }
+    ///
+    ///     let vcpu_fd = vm.create_vcpu(0).unwrap();
+    ///
+    ///     let mut vcpu_sregs = vcpu_fd.get_sregs().unwrap();
+    ///     vcpu_sregs.cs.base = 0;
+    ///     vcpu_sregs.cs.selector = 0;
+    ///     vcpu_fd.set_sregs(&vcpu_sregs).unwrap();
+    ///
+    ///     let mut vcpu_regs = vcpu_fd.get_regs().unwrap();
+    ///     // Set the Instruction Pointer to the guest address where we loaded the code.
+    ///     vcpu_regs.rip = guest_addr;
+    ///     vcpu_regs.rax = 2;
+    ///     vcpu_regs.rbx = 3;
+    ///     vcpu_regs.rflags = 2;
+    ///     vcpu_fd.set_regs(&vcpu_regs).unwrap();
+    ///
+    ///     loop {
+    ///         match vcpu_fd.run().expect("run failed") {
+    ///             VcpuExit::Hlt => {
+    ///                 break;
+    ///             }
+    ///             exit_reason => panic!("unexpected exit reason: {:?}", exit_reason),
+    ///         }
+    ///     }
+    /// }
+    /// ```
     ///
     pub fn run(&self) -> Result<VcpuExit> {
         // Safe because we know that our file is a vCPU fd and we verify the return result.

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -278,7 +278,7 @@ impl VmFd {
     }
 
     /// Get the `kvm_run` size.
-    pub fn get_run_size(&self) -> usize {
+    pub fn run_size(&self) -> usize {
         self.run_size
     }
 }

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -21,6 +21,10 @@ use kvm_ioctls::*;
 use sys_ioctl::*;
 
 /// An address either in programmable I/O space or in memory mapped I/O space.
+///
+/// The `IoEventAddress` is used for specifying the type when registering an event
+/// in [register_ioevent](struct.VmFd.html#method.register_ioevent).
+///
 pub enum IoEventAddress {
     /// Representation of an programmable I/O address.
     Pio(u64),
@@ -28,7 +32,13 @@ pub enum IoEventAddress {
     Mmio(u64),
 }
 
-/// Used in `VmFd::register_ioevent` to indicate that no datamatch is requested.
+/// Helper structure for disabling datamatch.
+///
+/// The structure can be used as a parameter to
+/// [`register_ioevent`](struct.VmFd.html#method.register_ioevent)
+/// to disable filtering of events based on the datamatch flag. For details check the
+/// [KVM API documentation](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt).
+///
 pub struct NoDatamatch;
 impl Into<u64> for NoDatamatch {
     fn into(self) -> u64 {
@@ -36,7 +46,7 @@ impl Into<u64> for NoDatamatch {
     }
 }
 
-/// A wrapper around creating and using a VM.
+/// Wrapper over KVM VM ioctls.
 pub struct VmFd {
     vm: File,
     run_size: usize,
@@ -46,6 +56,33 @@ impl VmFd {
     /// Creates/modifies a guest physical memory slot.
     ///
     /// See the documentation for `KVM_SET_USER_MEMORY_REGION`.
+    ///
+    /// # Arguments
+    ///
+    /// * `user_memory_region` - Guest physical memory slot. For details check the
+    ///             `kvm_userspace_memory_region` structure in the
+    ///             [KVM API doc](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// extern crate kvm_bindings;
+    ///
+    /// use kvm_ioctls::{Kvm, VmFd};
+    /// use kvm_bindings::kvm_userspace_memory_region;
+    ///
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// let mem_region = kvm_userspace_memory_region {
+    ///                     slot: 0,
+    ///                     guest_phys_addr: 0x1000 as u64,
+    ///                     memory_size: 0x4000 as u64,
+    ///                     userspace_addr: 0x0 as u64,
+    ///                     flags: 0,
+    ///                 };
+    /// vm.set_user_memory_region(mem_region).unwrap();
+    /// ```
     ///
     pub fn set_user_memory_region(
         &self,
@@ -62,11 +99,21 @@ impl VmFd {
 
     /// Sets the address of the three-page region in the VM's address space.
     ///
-    /// See the documentation on the `KVM_SET_TSS_ADDR` ioctl.
+    /// See the documentation for `KVM_SET_TSS_ADDR`.
     ///
     /// # Arguments
     ///
     /// * `offset` - Physical address of a three-page region in the guest's physical address space.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// # use kvm_ioctls::{Kvm, VmFd};
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// vm.set_tss_address(0xfffb_d000).unwrap();
+    /// ```
     ///
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn set_tss_address(&self, offset: usize) -> Result<()> {
@@ -82,6 +129,18 @@ impl VmFd {
     /// Creates an in-kernel interrupt controller.
     ///
     /// See the documentation for `KVM_CREATE_IRQCHIP`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// # use kvm_ioctls::{Kvm, VmFd};
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    ///
+    /// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    /// vm.create_irq_chip().unwrap();
+    /// ```
     ///
     #[cfg(any(
         target_arch = "x86",
@@ -101,6 +160,24 @@ impl VmFd {
 
     /// Creates a PIT as per the `KVM_CREATE_PIT2` ioctl.
     ///
+    /// # Arguments
+    ///
+    /// * pit_config - PIT configuration. For details check the `kvm_pit_config` structure in the
+    ///                [KVM API doc](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt).
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// extern crate kvm_bindings;
+    /// # use kvm_ioctls::{Kvm, VmFd};
+    /// use kvm_bindings::kvm_pit_config;
+    ///
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// let pit_config = kvm_pit_config::default();
+    /// vm.create_pit2(pit_config).unwrap();
+    /// ```
+    ///
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn create_pit2(&self, pit_config: kvm_pit_config) -> Result<()> {
         // Safe because we know that our file is a VM fd, we know the kernel will only read the
@@ -115,6 +192,8 @@ impl VmFd {
 
     /// Registers an event to be signaled whenever a certain address is written to.
     ///
+    /// See the documentation for `KVM_IOEVENTFD`.
+    ///
     /// # Arguments
     ///
     /// * `fd` - FD which will be signaled. When signaling, the usual `vmexit` to userspace
@@ -123,6 +202,25 @@ impl VmFd {
     /// * `datamatch` - Limits signaling `fd` to only the cases where the value being written is
     ///                 equal to this parameter. The size of `datamatch` is important and it must
     ///                 match the expected size of the guest's write.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// extern crate libc;
+    /// # use kvm_ioctls::{IoEventAddress, Kvm, NoDatamatch, VmFd};
+    /// use libc::{eventfd, EFD_NONBLOCK};
+    ///
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm_fd = kvm.create_vm().unwrap();
+    /// let evtfd = unsafe { eventfd(0, EFD_NONBLOCK) };
+    /// vm_fd
+    ///    .register_ioevent(evtfd, &IoEventAddress::Pio(0xf4), NoDatamatch)
+    ///    .unwrap();
+    /// vm_fd
+    ///    .register_ioevent(evtfd, &IoEventAddress::Mmio(0x1000), NoDatamatch)
+    ///    .unwrap();
+    /// ```
     ///
     pub fn register_ioevent<T: Into<u64>>(
         &self,
@@ -162,12 +260,94 @@ impl VmFd {
     /// Gets the bitmap of pages dirtied since the last call of this function.
     ///
     /// Leverages the dirty page logging feature in KVM. As a side-effect, this also resets the
-    /// bitmap inside the kernel.
+    /// bitmap inside the kernel. For the dirty log to be available, you have to set the flag
+    /// `KVM_MEM_LOG_DIRTY_PAGES` when creating guest memory regions.
+    ///
+    /// Check the documentation for `KVM_GET_DIRTY_LOG`.
     ///
     /// # Arguments
     ///
     /// * `slot` - Guest memory slot identifier.
     /// * `memory_size` - Size of the memory region.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// # extern crate kvm_bindings;
+    /// # use std::io::Write;
+    /// # use std::ptr::null_mut;
+    /// # use std::slice;
+    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd, VcpuExit};
+    /// # use kvm_bindings::{kvm_userspace_memory_region, KVM_MEM_LOG_DIRTY_PAGES};
+    /// # let kvm = Kvm::new().unwrap();
+    /// # let vm = kvm.create_vm().unwrap();
+    /// // This examples is based on https://lwn.net/Articles/658511/.
+    /// let mem_size = 0x4000;
+    /// let guest_addr: u64 = 0x1000;
+    /// let load_addr: *mut u8 = unsafe {
+    ///     libc::mmap(
+    ///         null_mut(),
+    ///         mem_size,
+    ///         libc::PROT_READ | libc::PROT_WRITE,
+    ///         libc::MAP_ANONYMOUS | libc::MAP_SHARED | libc::MAP_NORESERVE,
+    ///         -1,
+    ///         0,
+    ///     ) as *mut u8
+    /// };
+    ///
+    /// // Initialize a guest memory region using the flag `KVM_MEM_LOG_DIRTY_PAGES`.
+    /// let mem_region = kvm_userspace_memory_region {
+    ///     slot: 0,
+    ///     guest_phys_addr: guest_addr,
+    ///     memory_size: mem_size as u64,
+    ///     userspace_addr: load_addr as u64,
+    ///     flags: KVM_MEM_LOG_DIRTY_PAGES,
+    /// };
+    /// vm.set_user_memory_region(mem_region).unwrap();
+    ///
+    /// // Dummy x86 code that just calls halt.
+    /// let x86_code = [
+    ///         0xf4,             /* hlt */
+    /// ];
+    ///
+    /// // Write the code in the guest memory. This will generate a dirty page.
+    /// unsafe {
+    ///     let mut slice = slice::from_raw_parts_mut(load_addr, mem_size);
+    ///     slice.write(&x86_code).unwrap();
+    /// }
+    ///
+    /// let vcpu_fd = vm.create_vcpu(0).unwrap();
+    ///
+    /// let mut vcpu_sregs = vcpu_fd.get_sregs().unwrap();
+    /// vcpu_sregs.cs.base = 0;
+    /// vcpu_sregs.cs.selector = 0;
+    /// vcpu_fd.set_sregs(&vcpu_sregs).unwrap();
+    ///
+    /// let mut vcpu_regs = vcpu_fd.get_regs().unwrap();
+    ///  // Set the Instruction Pointer to the guest address where we loaded the code.
+    /// vcpu_regs.rip = guest_addr;
+    /// vcpu_regs.rax = 2;
+    /// vcpu_regs.rbx = 3;
+    /// vcpu_regs.rflags = 2;
+    /// vcpu_fd.set_regs(&vcpu_regs).unwrap();
+    ///
+    /// loop {
+    ///     match vcpu_fd.run().expect("run failed") {
+    ///         VcpuExit::Hlt => {
+    ///             // The code snippet dirties 1 page when loading the code in memory.
+    ///             let dirty_pages_bitmap = vm.get_dirty_log(0, mem_size).unwrap();
+    ///             let dirty_pages = dirty_pages_bitmap
+    ///                     .into_iter()
+    ///                     .map(|page| page.count_ones())
+    ///                     .fold(0, |dirty_page_count, i| dirty_page_count + i);
+    ///             assert_eq!(dirty_pages, 1);
+    ///             break;
+    ///         }
+    ///         exit_reason => panic!("unexpected exit reason: {:?}", exit_reason),
+    ///     }
+    /// }
+    /// ```
     ///
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn get_dirty_log(&self, slot: u32, memory_size: usize) -> Result<Vec<u64>> {
@@ -207,6 +387,20 @@ impl VmFd {
     /// * `fd` - Event to be signaled.
     /// * `gsi` - IRQ to be triggered.
     ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// # extern crate libc;
+    /// # use kvm_ioctls::{Kvm, VmFd};
+    /// # use libc::{eventfd, EFD_NONBLOCK};
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// let evtfd = unsafe { eventfd(0, EFD_NONBLOCK) };
+    /// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    /// vm.register_irqfd(evtfd, 0).unwrap();
+    /// ```
+    ///
     #[cfg(any(
         target_arch = "x86",
         target_arch = "x86_64",
@@ -229,14 +423,30 @@ impl VmFd {
         }
     }
 
-    /// Creates a new KVM vCPU fd.
+    /// Creates a new KVM vCPU file descriptor and maps the memory corresponding
+    /// its `kvm_run` structure.
+    ///
+    /// See the documentation for `KVM_CREATE_VCPU`.
     ///
     /// # Arguments
     ///
-    /// * `id` - The CPU number between [0, max vs).
+    /// * `id` - The vCPU ID.
     ///
     /// # Errors
-    /// Returns an error when the VM fd is invalid or the vCPU memory cannot be mapped correctly.
+    ///
+    /// Returns an io::Error when the VM fd is invalid or the vCPU memory cannot
+    /// be mapped correctly.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// // Create one vCPU with the ID=0.
+    /// let vcpu = vm.create_vcpu(0);
+    /// ```
     ///
     pub fn create_vcpu(&self, id: u8) -> Result<VcpuFd> {
         // Safe because we know that vm is a VM fd and we verify the return result.
@@ -256,6 +466,43 @@ impl VmFd {
     }
 
     /// Creates an emulated device in the kernel.
+    ///
+    /// See the documentation for `KVM_CREATE_DEVICE`.
+    ///
+    /// # Arguments
+    ///
+    /// * `device`: device configuration. For details check the `kvm_create_device` structure in the
+    ///                [KVM API doc](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// # extern crate kvm_bindings;
+    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// use kvm_bindings::{
+    ///     kvm_device_type_KVM_DEV_TYPE_VFIO,
+    ///     kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3,
+    ///     KVM_CREATE_DEVICE_TEST,
+    /// };
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    ///
+    /// // Creating a device with the KVM_CREATE_DEVICE_TEST flag to check
+    /// // whether the device type is supported. This will not create the device.
+    /// // To create the device the flag needs to be removed.
+    /// let mut device = kvm_bindings::kvm_create_device {
+    ///     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    ///     type_: kvm_device_type_KVM_DEV_TYPE_VFIO,
+    ///     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    ///     type_: kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3,
+    ///     fd: 0,
+    ///     flags: KVM_CREATE_DEVICE_TEST,
+    /// };
+    /// let device_fd = vm
+    ///     .create_device(&mut device).unwrap();
+    /// ```
+    ///
     pub fn create_device(&self, device: &mut kvm_create_device) -> Result<DeviceFd> {
         let ret = unsafe { ioctl_with_ref(self, KVM_CREATE_DEVICE(), device) };
         if ret == 0 {
@@ -265,7 +512,29 @@ impl VmFd {
         }
     }
 
-    /// This queries the kernel for the preferred target CPU type.
+    /// Returns the preferred CPU target type which can be emulated by KVM on underlying host.
+    ///
+    /// The preferred CPU target is returned in the `kvi` parameter.
+    /// See documentation for `KVM_ARM_PREFERRED_TARGET`.
+    ///
+    /// # Arguments
+    /// * `kvi` - CPU target configuration (out). For details check the `kvm_vcpu_init`
+    ///           structure in the
+    ///           [KVM API doc](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate kvm_ioctls;
+    /// # extern crate kvm_bindings;
+    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// use kvm_bindings::kvm_vcpu_init;
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// let mut kvi = kvm_vcpu_init::default();
+    /// vm.get_preferred_target(&mut kvi).unwrap();
+    /// ```
+    ///
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     pub fn get_preferred_target(&self, kvi: &mut kvm_vcpu_init) -> Result<()> {
         // The ioctl is safe because we allocated the struct and we know the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use cap::Cap;
 pub use ioctls::device::DeviceFd;
 pub use ioctls::system::Kvm;
 pub use ioctls::vcpu::{VcpuExit, VcpuFd};
-pub use ioctls::vm::VmFd;
+pub use ioctls::vm::{IoEventAddress, NoDatamatch, VmFd};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub use ioctls::CpuId;
 // The following example is used to verify that our public


### PR DESCRIPTION
## Changes
Added examples and more details for public functions.
Also renamed get_run_size() to run_size().

## Note:
`cargo test` will also run the documentation examples. Even if some examples are simple and just call the function it can help us in the future to keep the documentation updated as we make code changes (cargo test fails otherwise).

## How to test it locally
The best way to review this PR is by generating the documentation as follows:

```
# Clone Repo
git clone git@github.com:rust-vmm/kvm-ioctls.git
cd kvm-ioctls
# Fetch the code from my fork 
git fetch https://github.com/andreeaflorescu/kvm-ioctls.git pub_docs
git checkout FETCH_HEAD
# Generate and open the documentation 
cargo doc --open
```

## Still missing

High level crate design & usage. Will add this as part of fixing #21 
