### PR TITLE
lib: Export CpuId, KvmRunWrapper and Result

### DIFF
--- a/src/ioctls/mod.rs
+++ b/src/ioctls/mod.rs
@@ -106,6 +106,13 @@ impl CpuId {
     ///
     /// * `array_len` - Maximum number of CPUID entries.
     ///
+    /// # Example
+    ///
+    /// ```
+    /// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    /// use kvm_ioctls::CpuId;
+    /// let cpu_id = CpuId::new(32);
+    /// ```
     pub fn new(array_len: usize) -> CpuId {
         let mut kvm_cpuid = vec_with_array_field::<kvm_cpuid2, kvm_cpuid_entry2>(array_len);
         kvm_cpuid[0].nent = array_len as u32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,8 @@ pub use ioctls::system::Kvm;
 pub use ioctls::vcpu::{VcpuExit, VcpuFd};
 pub use ioctls::vm::VmFd;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use ioctls::CpuId;
-use ioctls::{KvmRunWrapper, Result};
+pub use ioctls::CpuId;
+pub use ioctls::{KvmRunWrapper, Result};
 
 /// Maximum number of CPUID entries that can be returned by a call to KVM ioctls.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,14 @@ pub use ioctls::vcpu::{VcpuExit, VcpuFd};
 pub use ioctls::vm::VmFd;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub use ioctls::CpuId;
+// The following example is used to verify that our public
+// structures are exported properly.
+/// # Example
+///
+/// ```
+/// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+/// use kvm_ioctls::{KvmRunWrapper, Result};
+/// ```
 pub use ioctls::{KvmRunWrapper, Result};
 
 /// Maximum number of CPUID entries that can be returned by a call to KVM ioctls.


### PR DESCRIPTION
They were unexported by commit 95279983.

Fixes: #14

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>