### PR TITLE
Fix warnings

### DIFF
--- a/src/ioctls/device.rs
+++ b/src/ioctls/device.rs
@@ -3,7 +3,7 @@
 
 use std::fs::File;
 use std::io;
-use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::io::{AsRawFd, RawFd};
 
 use kvm_bindings::kvm_device_attr;
 
@@ -49,14 +49,15 @@ mod tests {
     use super::*;
     use ioctls::system::Kvm;
     use kvm_bindings::{
-        kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3, kvm_device_type_KVM_DEV_TYPE_FSL_MPIC_20,
-        kvm_device_type_KVM_DEV_TYPE_VFIO, KVM_CREATE_DEVICE_TEST, KVM_DEV_VFIO_GROUP,
-        KVM_DEV_VFIO_GROUP_ADD,
+        kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3, kvm_device_type_KVM_DEV_TYPE_VFIO,
+        KVM_CREATE_DEVICE_TEST, KVM_DEV_VFIO_GROUP, KVM_DEV_VFIO_GROUP_ADD,
     };
-    use std::io::{Error, ErrorKind};
 
     #[test]
     fn test_create_device() {
+        #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+        use kvm_bindings::kvm_device_type_KVM_DEV_TYPE_FSL_MPIC_20;
+
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
 

--- a/src/ioctls/device.rs
+++ b/src/ioctls/device.rs
@@ -88,7 +88,7 @@ mod tests {
             addr: 0x0,
             flags: 0,
         };
-        device_fd.set_device_attr(&dist_attr);
+
         // We are just creating a test device. Creating a real device would make the CI dependent
         // on host configuration (like having /dev/vfio). We expect this to fail.
         assert!(device_fd.set_device_attr(&dist_attr).is_err());

--- a/src/ioctls/mod.rs
+++ b/src/ioctls/mod.rs
@@ -6,6 +6,7 @@
 // found in the THIRD-PARTY file.
 
 use std::io;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use std::mem::size_of;
 use std::os::unix::io::AsRawFd;
 use std::ptr::null_mut;
@@ -31,6 +32,7 @@ pub mod vm;
 pub type Result<T> = result::Result<T, io::Error>;
 
 // Returns a `Vec<T>` with a size in bytes at least as large as `size_in_bytes`.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn vec_with_size_in_bytes<T: Default>(size_in_bytes: usize) -> Vec<T> {
     let rounded_size = (size_in_bytes + size_of::<T>() - 1) / size_of::<T>();
     let mut v = Vec::with_capacity(rounded_size);
@@ -55,6 +57,7 @@ fn vec_with_size_in_bytes<T: Default>(size_in_bytes: usize) -> Vec<T> {
 // for `Foo`, a `Vec<Foo>` is created. Only the first element of `Vec<Foo>` would actually be used
 // as a `Foo`. The remaining memory in the `Vec<Foo>` is for `entries`, which must be contiguous
 // with `Foo`. This function is used to make the `Vec<Foo>` with enough space for `count` entries.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn vec_with_array_field<T: Default, F>(count: usize) -> Vec<T> {
     let element_space = count * size_of::<F>();
     let vec_size_bytes = size_of::<T>() + element_space;

--- a/src/ioctls/system.rs
+++ b/src/ioctls/system.rs
@@ -4,8 +4,8 @@
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
-
-use kvm_bindings::*;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use kvm_bindings::kvm_msr_list;
 
 use libc::{open, O_CLOEXEC, O_RDWR};
 use std::fs::File;
@@ -14,6 +14,7 @@ use std::os::raw::{c_char, c_ulong};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 
 use cap::Cap;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use ioctls::vec_with_array_field;
 use ioctls::vm::{new_vmfd, VmFd};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -383,6 +384,7 @@ impl AsRawFd for Kvm {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use MAX_KVM_CPUID_ENTRIES;
 
     #[test]

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -4,7 +4,7 @@
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
-
+#![allow(unused)]
 use super::sys_ioctl::*;
 use kvm_bindings::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
-#![allow(unused)]
 #![deny(missing_docs)]
 
 //! A safe wrapper around the kernel's KVM interface.


### PR DESCRIPTION
The warnings were hidden because in `src/lib.rs` we were using the `allow(unused)` macro. This unfortunately also hides the result unused warning.