### PR TITLE
remove x86 labeling for KVM_GET_DIRTY_LOG

### DIFF
--- a/src/ioctls/system.rs
+++ b/src/ioctls/system.rs
@@ -480,7 +480,6 @@ mod tests {
         {
             assert_eq!(get_raw_errno(faulty_kvm.get_emulated_cpuid(4)), badf_errno);
             assert_eq!(get_raw_errno(faulty_kvm.get_supported_cpuid(4)), badf_errno);
-
             assert_eq!(get_raw_errno(faulty_kvm.get_msr_index_list()), badf_errno);
         }
         assert_eq!(get_raw_errno(faulty_kvm.create_vm()), badf_errno);


### PR DESCRIPTION
KVM_GET_DIRTY_LOG is supported on arm too.
Look for kvm_vm_ioctl_get_dirty_log inside
linux's source file arch/arm/kvm/arm.c.
Helps with [Firecracker Issue](https://github.com/firecracker-microvm/firecracker/issues/866).

Signed-off-by: Diana Popa <dpopa@amazon.com>