### PR TITLE
mark `set_user_memory_region` as unsafe

### DIFF
--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -620,7 +620,7 @@ impl VcpuFd {
     ///         userspace_addr: load_addr as u64,
     ///         flags: 0,
     ///     };
-    ///     vm.set_user_memory_region(mem_region).unwrap();
+    ///     unsafe { vm.set_user_memory_region(mem_region).unwrap() };
     ///
     ///     // Dummy x86 code that just calls halt.
     ///     let x86_code = [
@@ -961,7 +961,9 @@ mod tests {
             userspace_addr: load_addr as u64,
             flags: KVM_MEM_LOG_DIRTY_PAGES,
         };
-        vm.set_user_memory_region(mem_region).unwrap();
+        unsafe {
+            vm.set_user_memory_region(mem_region).unwrap();
+        }
 
         unsafe {
             // Get a mutable slice of `mem_size` from `load_addr`.

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -83,15 +83,16 @@ impl VmFd {
     ///                     userspace_addr: 0x0 as u64,
     ///                     flags: 0,
     ///                 };
-    /// vm.set_user_memory_region(mem_region).unwrap();
+    /// unsafe {
+    ///     vm.set_user_memory_region(mem_region).unwrap();
+    /// };
     /// ```
     ///
-    pub fn set_user_memory_region(
+    pub unsafe fn set_user_memory_region(
         &self,
         user_memory_region: kvm_userspace_memory_region,
     ) -> Result<()> {
-        let ret =
-            unsafe { ioctl_with_ref(self, KVM_SET_USER_MEMORY_REGION(), &user_memory_region) };
+        let ret = ioctl_with_ref(self, KVM_SET_USER_MEMORY_REGION(), &user_memory_region);
         if ret == 0 {
             Ok(())
         } else {
@@ -306,7 +307,7 @@ impl VmFd {
     ///     userspace_addr: load_addr as u64,
     ///     flags: KVM_MEM_LOG_DIRTY_PAGES,
     /// };
-    /// vm.set_user_memory_region(mem_region).unwrap();
+    /// unsafe { vm.set_user_memory_region(mem_region).unwrap() };
     ///
     /// // Dummy x86 code that just calls halt.
     /// let x86_code = [
@@ -587,7 +588,7 @@ mod tests {
             userspace_addr: 0,
             flags: 0,
         };
-        assert!(vm.set_user_memory_region(invalid_mem_region).is_err());
+        assert!(unsafe { vm.set_user_memory_region(invalid_mem_region) }.is_err());
     }
 
     #[test]
@@ -701,7 +702,7 @@ mod tests {
         }
 
         assert_eq!(
-            get_raw_errno(faulty_vm_fd.set_user_memory_region(invalid_mem_region)),
+            get_raw_errno(unsafe { faulty_vm_fd.set_user_memory_region(invalid_mem_region) }),
             badf_errno
         );
         assert_eq!(get_raw_errno(faulty_vm_fd.set_tss_address(0)), badf_errno);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@
 //!         userspace_addr: load_addr as u64,
 //!         flags: KVM_MEM_LOG_DIRTY_PAGES,
 //!     };
-//!     vm.set_user_memory_region(mem_region).unwrap();
+//!     unsafe { vm.set_user_memory_region(mem_region).unwrap() };
 //!
 //!
 //!     let x86_code = [


### PR DESCRIPTION
This function uses as parameter kvm_userspace_memory_region which is
a wrapper over a raw pointer (userspace_addr) and the size
(memory_size) so cannot know if the pointer refers to a valid memory.

Fixes: https://github.com/rust-vmm/kvm-ioctls/issues/38