### PR TITLE
updated documentation for set_user_memory_region

### DIFF
--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -65,6 +65,15 @@ impl VmFd {
     ///             `kvm_userspace_memory_region` structure in the
     ///             [KVM API doc](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt).
     ///
+    /// # Safety
+    ///
+    /// This function is unsafe because there is no guarantee `userspace_addr` points to a valid
+    /// memory region, nor the memory region lives as long as the kernel needs it to.
+    ///
+    /// The caller of this method must make sure that:
+    /// - the raw pointer (`userspace_addr`) points to valid memory
+    /// - the regions provided to KVM are not overlapping other memory regions.
+    ///
     /// # Example
     ///
     /// ```rust


### PR DESCRIPTION
Added Safety section which explains why is the function unsafe and
what guarantees the caller needs to provide.