### PR TITLE
Switch to Container v2

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -112,7 +112,7 @@ steps:
 
   - label: "clippy-x86"
     commands:
-     - cargo clippy --all
+     - cargo clippy --all -- -D warnings
     retry:
       automatic: false
     agents:
@@ -124,7 +124,7 @@ steps:
 
   - label: "clippy-arm"
     commands:
-     - cargo clippy --all
+     - cargo clippy --all -- -D warnings
     retry:
       automatic: false
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ steps:
       platform: x86_64.metal
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v1"
+          image: "rustvmm/dev:v2"
           always-pull: true
 
   - label: "build-gnu-arm"
@@ -20,7 +20,7 @@ steps:
       platform: arm.metal
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v1"
+          image: "rustvmm/dev:v2"
           always-pull: true
 
   - label: "build-musl-x86"
@@ -32,7 +32,7 @@ steps:
       platform: x86_64.metal
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v1"
+          image: "rustvmm/dev:v2"
           always-pull: true
 
   - label: "build-musl-arm"
@@ -44,7 +44,7 @@ steps:
       platform: arm.metal
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v1"
+          image: "rustvmm/dev:v2"
           always-pull: true
 
   - label: "style"
@@ -55,7 +55,7 @@ steps:
       platform: x86_64.metal
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v1"
+          image: "rustvmm/dev:v2"
           always-pull: true
 
   - label: "unittests-gnu-x86"
@@ -68,7 +68,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v1"
+          image: "rustvmm/dev:v2"
           always-pull: true
 
   - label: "unittests-gnu-arm"
@@ -81,7 +81,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v1"
+          image: "rustvmm/dev:v2"
           always-pull: true
 
   - label: "unittests-musl-x86"
@@ -94,7 +94,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v1"
+          image: "rustvmm/dev:v2"
           always-pull: true
 
   - label: "unittests-musl-arm"
@@ -107,7 +107,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v1"
+          image: "rustvmm/dev:v2"
           always-pull: true
 
   - label: "clippy-x86"
@@ -119,7 +119,7 @@ steps:
       platform: x86_64.metal
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v1"
+          image: "rustvmm/dev:v2"
           always-pull: true
 
   - label: "coverage-x86"
@@ -132,7 +132,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v1"
+          image: "rustvmm/dev:v2"
           always-pull: true
 
   - label: "check-warnings-x86"
@@ -145,7 +145,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v1"
+          image: "rustvmm/dev:v2"
           always-pull: true
 
   - label: "check-warnings-arm"
@@ -158,5 +158,5 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v1"
+          image: "rustvmm/dev:v2"
           always-pull: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -122,6 +122,18 @@ steps:
           image: "rustvmm/dev:v2"
           always-pull: true
 
+  - label: "clippy-arm"
+    commands:
+     - cargo clippy --all
+    retry:
+      automatic: false
+    agents:
+      platform: arm.metal
+    plugins:
+      - docker#v3.0.1:
+          image: "rustvmm/dev:v2"
+          always-pull: true
+
   - label: "coverage-x86"
     commands:
       - pytest tests/test_coverage.py

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ docker run --device=/dev/kvm \
            -it \
            --security-opt seccomp=unconfined \
            --volume $(pwd)/kvm-ioctls:/kvm-ioctls \
-           fandree/rust-vmm-dev
+           rustvmm/dev:v2
 cd kvm-ioctls/
 cargo test
 ```
@@ -76,7 +76,7 @@ docker run --device=/dev/kvm \
            -it \
            --security-opt seccomp=unconfined \
            --volume $(pwd)/kvm-ioctls:/kvm-ioctls \
-           fandree/rust-vmm-dev
+           rustvmm/dev:v2
 cd kvm-ioctls/
 pytest --profile=devel tests/test_coverage.py
 ```

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -511,7 +511,7 @@ impl VmFd {
         if ret == 0 {
             Ok(new_device(unsafe { File::from_raw_fd(device.fd as i32) }))
         } else {
-            return Err(io::Error::last_os_error());
+            Err(io::Error::last_os_error())
         }
     }
 


### PR DESCRIPTION
The v2 tag of the container uses Rust 1.34.0 and also has clippy installed for aarch64 builds.
Added clippy for aarch64 as well.