### PR TITLE
Add support for KVM_SET_GSI_ROUTING ioctl

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.0,
+  "coverage_score": 91.1,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -40,6 +40,13 @@ ioctl_io_nr!(KVM_CREATE_IRQCHIP, KVMIO, 0x60);
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "arm",
+    target_arch = "aarch64"
+))]
+ioctl_iow_nr!(KVM_SET_GSI_ROUTING, KVMIO, 0x6a, kvm_irq_routing);
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "arm",
     target_arch = "aarch64",
     target_arch = "s390"
 ))]


### PR DESCRIPTION
By adding the support for the ioctl KVM_SET_GSI_ROUTING, this commit
will allow consumers of the kvm-ioctls crate to set custom mappings for
GSI entries.

This would let a caller of this ioctl defines that GSI number X can
trigger an interrupt by delivering an MSI directly to the local APIC or
instead deliver a pin based interrupt to the in-kernel IOAPIC.

One example that comes to mind is to use this ioctl to let a VMM
interact with the VFIO API, as it requires an eventfd to be associated
with each interrupt. By combining this ioctl with KVM_IRQFD, one could
directly map an interrupt to an eventfd managed by KVM, and associated
to a specific GSI.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>