### PR TITLE
Add unregister_irqfd() to VmFd

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.1,
+  "coverage_score": 91.3,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
Add unregister_irqfd() to VmFd to unregister an irqfd from the KVM,
which will be needed when enabling supoort of MSI.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>