### PR TITLE
reimplement CpuId as a FamStructWrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -24,7 +25,16 @@ name = "libc"
 version = "0.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "vmm-sys-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c223e8703d2eb76d990c5f58e29c85b0f6f50e24b823babde927948e7c71fc03"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
+"checksum vmm-sys-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "46996f56aeae31fbc0532ae57a944e00089302f03b18c10c76eebfd9249f4a6c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0 OR MIT"
 [dependencies]
 libc = ">=0.2.39"
 kvm-bindings = ">=0.1.0"
+vmm-sys-util = ">=0.1.1"
 
 [dev-dependencies]
 byteorder = ">=1.2.1"

--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.3,
+  "coverage_score": 91.0,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -325,7 +325,7 @@ impl VcpuFd {
     /// // Update the CPUID entries to disable the EPB feature.
     /// const ECX_EPB_SHIFT: u32 = 3;
     /// {
-    ///     let entries = kvm_cpuid.mut_entries_slice();
+    ///     let entries = kvm_cpuid.as_mut_slice();
     ///     for entry in entries.iter_mut() {
     ///         match entry.function {
     ///             6 => entry.ecx &= !(1 << ECX_EPB_SHIFT),
@@ -341,7 +341,7 @@ impl VcpuFd {
     pub fn set_cpuid2(&self, cpuid: &CpuId) -> Result<()> {
         let ret = unsafe {
             // Here we trust the kernel not to read past the end of the kvm_cpuid2 struct.
-            ioctl_with_ptr(self, KVM_SET_CPUID2(), cpuid.as_ptr())
+            ioctl_with_ptr(self, KVM_SET_CPUID2(), cpuid.as_fam_struct_ptr())
         };
         if ret < 0 {
             return Err(io::Error::last_os_error());
@@ -803,7 +803,7 @@ mod tests {
         if kvm.check_extension(Cap::ExtCpuid) {
             let vm = kvm.create_vm().unwrap();
             let mut cpuid = kvm.get_supported_cpuid(MAX_KVM_CPUID_ENTRIES).unwrap();
-            assert!(cpuid.mut_entries_slice().len() <= MAX_KVM_CPUID_ENTRIES);
+            assert!(cpuid.as_mut_slice().len() <= MAX_KVM_CPUID_ENTRIES);
             let nr_vcpus = kvm.get_nr_vcpus();
             for cpu_id in 0..nr_vcpus {
                 let vcpu = vm.create_vcpu(cpu_id as u8).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,7 @@
 
 extern crate kvm_bindings;
 extern crate libc;
+extern crate vmm_sys_util;
 
 #[macro_use]
 mod sys_ioctl;
@@ -193,7 +194,7 @@ pub use ioctls::system::Kvm;
 pub use ioctls::vcpu::{VcpuExit, VcpuFd};
 pub use ioctls::vm::{IoEventAddress, NoDatamatch, VmFd};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub use ioctls::CpuId;
+pub use ioctls::{CpuId, MAX_KVM_CPUID_ENTRIES};
 // The following example is used to verify that our public
 // structures are exported properly.
 /// # Example
@@ -203,10 +204,3 @@ pub use ioctls::CpuId;
 /// use kvm_ioctls::{KvmRunWrapper, Result};
 /// ```
 pub use ioctls::{KvmRunWrapper, Result};
-
-/// Maximum number of CPUID entries that can be returned by a call to KVM ioctls.
-///
-/// This value is taken from Linux Kernel v4.14.13 (arch/x86/include/asm/kvm_host.h).
-/// It can be used for calls to [get_supported_cpuid](struct.Kvm.html#method.get_supported_cpuid) and
-/// [get_emulated_cpuid](struct.Kvm.html#method.get_emulated_cpuid).
-pub const MAX_KVM_CPUID_ENTRIES: usize = 80;


### PR DESCRIPTION
The CpuId type was implemented as a wrapper over the kvm_cpuid2
structure. Since kvm_cpuid2 contains a flexible array member,
we can reimplement CpuId as a FamStructWrapper<kvm_cpuid2>.

Signed-off-by: Serban Iorga <seriorga@amazon.com>