### PR TITLE
add a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# v0.2.0
+
+## Added
+- Add support for `KVM_ENABLE_CAP`.
+- Add support for `KVM_SIGNAL_MSI`.
+
+## Fixed
+- Fix bug in KvmRunWrapper. The memory for kvm_run struct was not unmapped
+  after the KvmRunWrapper object got out of scope.
+- Return proper value when receiving the EOI KVM exit.
+- Mark set_user_memory_region as unsafe.
+
+# v0.1.0
+
+First release of the kvm-ioctls crate.
+
+The kvm-ioctls crate provides safe wrappers over the KVM API, a set of ioctls
+used for creating and configuring Virtual Machines (VMs) on Linux.
+The ioctls are accessible through four structures:
+- Kvm - wrappers over system ioctls
+- VmFd - wrappers over VM ioctls
+- VcpuFd - wrappers over vCPU ioctls
+- DeviceFd - wrappers over device ioctls
+
+The kvm-ioctls can be used on x86_64 and aarch64. Right now the aarch64
+support is considered experimental.


### PR DESCRIPTION
Added a changelog with details about the 2 past releases of
kvm-ioctls.

The changelog follows the format defined in
https://keepachangelog.com/en/1.0.0/.