### PR TITLE
Implement FromRawFd for DeviceFd

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.0,
+  "coverage_score": 90.3,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
Implement FromRawFd for DeviceFd to recreate a DeviceFd object from a
raw fd.
Also export VmFd::new_vmfd() as pub.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>