### PR TITLE
Support for getting dirty logs on aarch64

### DIFF
--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -1192,7 +1192,6 @@ impl AsRawFd for VcpuFd {
 mod tests {
     extern crate byteorder;
 
-    #[cfg(target_arch = "x86_64")]
     use super::*;
     use ioctls::system::Kvm;
     #[cfg(any(
@@ -1205,7 +1204,6 @@ mod tests {
 
     // Helper function for memory mapping `size` bytes of anonymous memory.
     // Panics if the mmap fails.
-    #[cfg(target_arch = "x86_64")]
     fn mmap_anonymous(size: usize) -> *mut u8 {
         use std::ptr::null_mut;
 
@@ -1427,6 +1425,101 @@ mod tests {
             vcpu.set_vcpu_events(&vcpu_events).unwrap();
             let other_vcpu_events = vcpu.get_vcpu_events().unwrap();
             assert_eq!(vcpu_events, other_vcpu_events);
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn test_run_code() {
+        use std::io::Write;
+
+        let kvm = Kvm::new().unwrap();
+        let vm = kvm.create_vm().unwrap();
+        #[rustfmt::skip]
+        let code = [
+            0x40, 0x20, 0x80, 0x52, /* mov w0, #0x102 */
+            0x00, 0x01, 0x00, 0xb9, /* str w0, [x8]; test physical memory write */
+            0x81, 0x60, 0x80, 0x52, /* mov w1, #0x304 */
+            0x02, 0x00, 0x80, 0x52, /* mov w2, #0x0 */
+            0x20, 0x01, 0x40, 0xb9, /* ldr w0, [x9]; test MMIO read */
+            0x1f, 0x18, 0x14, 0x71, /* cmp w0, #0x506 */
+            0x20, 0x00, 0x82, 0x1a, /* csel w0, w1, w2, eq */
+            0x20, 0x01, 0x00, 0xb9, /* str w0, [x9]; test MMIO write */
+            0x00, 0x00, 0x00, 0x14, /* b <this address>; shouldn't get here, but if so loop forever */
+        ];
+
+        let mem_size = 0x20000;
+        let load_addr = mmap_anonymous(mem_size);
+        let guest_addr: u64 = 0x10000;
+        let slot: u32 = 0;
+        let mem_region = kvm_userspace_memory_region {
+            slot,
+            guest_phys_addr: guest_addr,
+            memory_size: mem_size as u64,
+            userspace_addr: load_addr as u64,
+            flags: KVM_MEM_LOG_DIRTY_PAGES,
+        };
+        unsafe {
+            vm.set_user_memory_region(mem_region).unwrap();
+        }
+
+        unsafe {
+            // Get a mutable slice of `mem_size` from `load_addr`.
+            // This is safe because we mapped it before.
+            let mut slice = std::slice::from_raw_parts_mut(load_addr, mem_size);
+            slice.write(&code).unwrap();
+        }
+
+        let vcpu_fd = vm.create_vcpu(0).unwrap();
+        let mut kvi = kvm_bindings::kvm_vcpu_init::default();
+        vm.get_preferred_target(&mut kvi).unwrap();
+        vcpu_fd.vcpu_init(&kvi).unwrap();
+
+        let core_reg_base: u64 = 0x6030_0000_0010_0000;
+        let mmio_addr: u64 = guest_addr + mem_size as u64;
+
+        // Set the PC to the guest address where we loaded the code.
+        vcpu_fd
+            .set_one_reg(core_reg_base + 2 * 32, guest_addr)
+            .unwrap();
+
+        // Set x8 and x9 to the addresses the guest test code needs
+        vcpu_fd
+            .set_one_reg(core_reg_base + 2 * 8, guest_addr + 0x10000)
+            .unwrap();
+        vcpu_fd
+            .set_one_reg(core_reg_base + 2 * 9, mmio_addr)
+            .unwrap();
+
+        loop {
+            match vcpu_fd.run().expect("run failed") {
+                VcpuExit::MmioRead(addr, data) => {
+                    assert_eq!(addr, mmio_addr);
+                    assert_eq!(data.len(), 4);
+                    data[3] = 0x0;
+                    data[2] = 0x0;
+                    data[1] = 0x5;
+                    data[0] = 0x6;
+                }
+                VcpuExit::MmioWrite(addr, data) => {
+                    assert_eq!(addr, mmio_addr);
+                    assert_eq!(data.len(), 4);
+                    assert_eq!(data[3], 0x0);
+                    assert_eq!(data[2], 0x0);
+                    assert_eq!(data[1], 0x3);
+                    assert_eq!(data[0], 0x4);
+                    // The code snippet dirties one page at guest_addr + 0x10000.
+                    // The code page should not be dirty, as it's not written by the guest.
+                    let dirty_pages_bitmap = vm.get_dirty_log(slot, mem_size).unwrap();
+                    let dirty_pages = dirty_pages_bitmap
+                        .into_iter()
+                        .map(|page| page.count_ones())
+                        .fold(0, |dirty_page_count, i| dirty_page_count + i);
+                    assert_eq!(dirty_pages, 1);
+                    break;
+                }
+                r => panic!("unexpected exit reason: {:?}", r),
+            }
         }
     }
 

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -87,8 +87,8 @@ impl VmFd {
     /// let vm = kvm.create_vm().unwrap();
     /// let mem_region = kvm_userspace_memory_region {
     ///                     slot: 0,
-    ///                     guest_phys_addr: 0x1000 as u64,
-    ///                     memory_size: 0x4000 as u64,
+    ///                     guest_phys_addr: 0x10000 as u64,
+    ///                     memory_size: 0x10000 as u64,
     ///                     userspace_addr: 0x0 as u64,
     ///                     flags: 0,
     ///                 };

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -25,7 +25,6 @@ ioctl_iowr_nr!(KVM_GET_EMULATED_CPUID, KVMIO, 0x09, kvm_cpuid2);
 // Ioctls for VM fds.
 
 ioctl_io_nr!(KVM_CREATE_VCPU, KVMIO, 0x41);
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iow_nr!(KVM_GET_DIRTY_LOG, KVMIO, 0x42, kvm_dirty_log);
 /* Available with KVM_CAP_USER_MEMORY */
 ioctl_iow_nr!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,9 @@
 //! # Example - Running a VM on x86_64
 //!
 //! In this example we are creating a Virtual Machine (VM) with one vCPU.
-//! On the vCPU we are running x86_64 specific code. This example is based on
+//! On the vCPU we are running machine specific code. This example is based on
 //! the [LWN article](https://lwn.net/Articles/658511/) on using the KVM API.
+//! The aarch64 example was modfied accordingly.
 //!
 //! To get code running on the vCPU we are going through the following steps:
 //!
@@ -37,7 +38,7 @@
 //!    are adding only one memory region and write the code in one memory page.
 //! 4. Create a vCPU using the VM object. The vCPU is used for running
 //!    [vCPU specific ioctls](struct.VcpuFd.html).
-//! 5. Setup x86 specific general purpose registers and special registers. For
+//! 5. Setup architectural specific general purpose registers and special registers. For
 //!    details about how and why these registers are set, please check the
 //!    [LWN article](https://lwn.net/Articles/658511/) on which this example is
 //!    built.
@@ -52,7 +53,6 @@
 //! use kvm_ioctls::{Kvm, VmFd, VcpuFd};
 //! use kvm_ioctls::VcpuExit;
 //!
-//! #[cfg(target_arch = "x86_64")]
 //! fn main(){
 //!     use std::io::Write;
 //!     use std::slice;
@@ -61,6 +61,34 @@
 //!     use kvm_bindings::KVM_MEM_LOG_DIRTY_PAGES;
 //!     use kvm_bindings::kvm_userspace_memory_region;
 //!
+//!	let mem_size = 0x4000;
+//!	let guest_addr = 0x1000;
+//!	let asm_code: &[u8];
+//!
+//!     // Setting up architectural dependent values.
+//!     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+//!    {
+//!        asm_code = &[
+//!         0xba, 0xf8, 0x03, /* mov $0x3f8, %dx */
+//!         0x00, 0xd8, /* add %bl, %al */
+//!         0x04, b'0', /* add $'0', %al */
+//!         0xee, /* out %al, %dx */
+//!         0xec, /* in %dx, %al */
+//!         0xc6, 0x06, 0x00, 0x80, 0x00, /* movl $0, (0x8000); This generates a MMIO Write.*/
+//!         0x8a, 0x16, 0x00, 0x80, /* movl (0x8000), %dl; This generates a MMIO Read.*/
+//!         0xf4, /* hlt */
+//!        ];
+//!    }
+//!    #[cfg(target_arch = "aarch64")]
+//!    {
+//!        asm_code = &[
+//!             0x01, 0x00, 0x00, 0x10, /* adr x1, <this address> */
+//!             0x22, 0x10, 0x00, 0xb9, /* str w2, [x1, #16]; write to this page */
+//!             0x02, 0x00, 0x00, 0xb9, /* str w2, [x0]; This generates a MMIO Write.*/
+//!             0x00, 0x00, 0x00, 0x14, /* b <this address>; shouldn't get here, but if so loop forever */
+//!         ];
+//!    }
+//!
 //!     // 1. Instantiate KVM.
 //!     let kvm = Kvm::new().unwrap();
 //!
@@ -68,8 +96,6 @@
 //!     let vm = kvm.create_vm().unwrap();
 //!
 //!     // 3. Initialize Guest Memory.
-//!     let mem_size = 0x4000;
-//!     let guest_addr: u64 = 0x1000;
 //!     let load_addr: *mut u8 = unsafe {
 //!         libc::mmap(
 //!             null_mut(),
@@ -93,39 +119,44 @@
 //!     };
 //!     unsafe { vm.set_user_memory_region(mem_region).unwrap() };
 //!
-//!
-//!     let x86_code = [
-//!         0xba, 0xf8, 0x03, /* mov $0x3f8, %dx */
-//!         0x00, 0xd8, /* add %bl, %al */
-//!         0x04, b'0', /* add $'0', %al */
-//!         0xee, /* out %al, %dx */
-//!         0xec, /* in %dx, %al */
-//!         0xc6, 0x06, 0x00, 0x80, 0x00, /* movl $0, (0x8000); This generates a MMIO Write.*/
-//!         0x8a, 0x16, 0x00, 0x80, /* movl (0x8000), %dl; This generates a MMIO Read.*/
-//!         0xf4, /* hlt */
-//!     ];
-//!
 //!     // Write the code in the guest memory. This will generate a dirty page.
 //!     unsafe {
 //!         let mut slice = slice::from_raw_parts_mut(load_addr, mem_size);
-//!         slice.write(&x86_code).unwrap();
+//!         slice.write(&asm_code).unwrap();
 //!     }
 //!
 //!     // 4. Create one vCPU.
 //!     let vcpu_fd = vm.create_vcpu(0).unwrap();
 //!
 //!     // 5. Initialize general purpose and special registers.
-//!     let mut vcpu_sregs = vcpu_fd.get_sregs().unwrap();
-//!     vcpu_sregs.cs.base = 0;
-//!     vcpu_sregs.cs.selector = 0;
-//!     vcpu_fd.set_sregs(&vcpu_sregs).unwrap();
+//!     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+//!     {
+//!         // x86_64 specific registry setup.
+//!         let mut vcpu_sregs = vcpu_fd.get_sregs().unwrap();
+//!         vcpu_sregs.cs.base = 0;
+//!         vcpu_sregs.cs.selector = 0;
+//!         vcpu_fd.set_sregs(&vcpu_sregs).unwrap();
 //!
-//!     let mut vcpu_regs = vcpu_fd.get_regs().unwrap();
-//!     vcpu_regs.rip = guest_addr;
-//!     vcpu_regs.rax = 2;
-//!     vcpu_regs.rbx = 3;
-//!     vcpu_regs.rflags = 2;
-//!     vcpu_fd.set_regs(&vcpu_regs).unwrap();
+//!         let mut vcpu_regs = vcpu_fd.get_regs().unwrap();
+//!         vcpu_regs.rip = guest_addr;
+//!         vcpu_regs.rax = 2;
+//!         vcpu_regs.rbx = 3;
+//!         vcpu_regs.rflags = 2;
+//!         vcpu_fd.set_regs(&vcpu_regs).unwrap();
+//!     }
+//!
+//!     #[cfg(target_arch = "aarch64")]
+//!     {
+//!         // aarch64 specific registry setup.
+//!         let mut kvi = kvm_bindings::kvm_vcpu_init::default();
+//!         vm.get_preferred_target(&mut kvi).unwrap();
+//!         vcpu_fd.vcpu_init(&kvi).unwrap();
+//!
+//!         let core_reg_base: u64 = 0x6030_0000_0010_0000;
+//!         let mmio_addr: u64 = guest_addr + mem_size as u64;
+//!         vcpu_fd.set_one_reg(core_reg_base + 2 * 32, guest_addr); // set PC
+//!         vcpu_fd.set_one_reg(core_reg_base + 2 * 0, mmio_addr); // set X0
+//!     }
 //!
 //!     // 6. Run code on the vCPU.
 //!     loop {
@@ -155,8 +186,6 @@
 //!                     "Received an MMIO Write Request to the address {:#x}.",
 //!                     addr,
 //!                 );
-//!             }
-//!             VcpuExit::Hlt => {
 //!                 // The code snippet dirties 1 page when it is loaded in memory
 //!                 let dirty_pages_bitmap = vm.get_dirty_log(slot, mem_size).unwrap();
 //!                 let dirty_pages = dirty_pages_bitmap
@@ -164,16 +193,18 @@
 //!                     .map(|page| page.count_ones())
 //!                     .fold(0, |dirty_page_count, i| dirty_page_count + i);
 //!                 assert_eq!(dirty_pages, 1);
+//!                 // Since on aarch64 there is not halt instruction,
+//!                 // we break immediately after the last known instruction
+//!                 // of the asm code example so that we avoid an infinite loop.
+//!                 #[cfg(target_arch = "aarch64")]
+//!                 break;
+//!             }
+//!             VcpuExit::Hlt => {
 //!                 break;
 //!             }
 //!             r => panic!("Unexpected exit reason: {:?}", r),
 //!         }
 //!     }
-//! }
-//!
-//! #[cfg(not(target_arch = "x86_64"))]
-//! fn main() {
-//!     println!("This code example only works on x86_64.");
 //! }
 //! ```
 


### PR DESCRIPTION
# Description of changes
This PR completes while also adjusting #33:
* `get_dirty_log` function is not `cfg` labeled anymore. The cfg labels were moved inside the doc comments for grouping architecturally specific variables and the examples was brought to a state that has as many similar line of codes between different architectures
* `test_run_code` was left as it was
* added main doc in `src/lib.rs` for aarch64 also