### PR TITLE
Add missing support to allow `vm` and `vcpu` serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Added
 - Support for setting vcpu `kvm_immediate_exit` flag
+- Support for vcpu `KVM_GET_CPUID2`
+- Support for vcpu `KVM_GET_MP_STATE`
+- Support for vcpu `KVM_SET_MP_STATE`
+- Support for vcpu `KVM_GET_VCPU_EVENTS`
+- Support for vcpu `KVM_SET_VCPU_EVENTS`
+- Support for vcpu `KVM_GET_DEBUGREGS`
+- Support for vcpu `KVM_SET_DEBUGREGS`
+- Support for vcpu `KVM_GET_XSAVE`
+- Support for vcpu `KVM_SET_XSAVE`
+- Support for vcpu `KVM_GET_XCRS`
+- Support for vcpu `KVM_SET_XCRS`
 
 ## Changed
 - Function offering support for `KVM_SET_MSRS` also returns the number

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
 - Support for vcpu `KVM_SET_XSAVE`
 - Support for vcpu `KVM_GET_XCRS`
 - Support for vcpu `KVM_SET_XCRS`
+- Support for vm `KVM_GET_IRQCHIP`
+- Support for vm `KVM_SET_IRQCHIP`
+- Support for vm `KVM_GET_CLOCK`
+- Support for vm `KVM_SET_CLOCK`
+- Support for vm `KVM_GET_PIT2`
+- Support for vm `KVM_SET_PIT2`
 
 ## Changed
 - Function offering support for `KVM_SET_MSRS` also returns the number

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Added
 - Support for setting vcpu `kvm_immediate_exit` flag
 
+## Changed
+- Function offering support for `KVM_SET_MSRS` also returns the number
+  of MSR entries successfully written.
+
 # v0.2.0
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Added
+- Support for setting vcpu `kvm_immediate_exit` flag
+
 # v0.2.0
 
 ## Added

--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 90.3,
+  "coverage_score": 92.3,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/ioctls/mod.rs
+++ b/src/ioctls/mod.rs
@@ -74,6 +74,10 @@ fn vec_with_array_field<T: Default, F>(count: usize) -> Vec<T> {
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub const MAX_KVM_CPUID_ENTRIES: usize = 80;
 
+/// Maximum number of MSRs KVM supports (See arch/x86/kvm/x86.c).
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub const KVM_MAX_MSR_ENTRIES: usize = 256;
+
 // We can't implement FamStruct directly for kvm_cpuid2.
 // We would get an "impl doesn't use types inside crate" error.
 // We have to create a shadow structure as a workaround.

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -737,6 +737,12 @@ impl VcpuFd {
             Err(io::Error::last_os_error())
         }
     }
+
+    /// Sets the `immediate_exit` flag on the `kvm_run` struct associated with this vCPU to `val`.
+    pub fn set_kvm_immediate_exit(&self, val: u8) {
+        let kvm_run = self.kvm_run_ptr.as_mut_ref();
+        kvm_run.immediate_exit = val;
+    }
 }
 
 /// Helper function to create a new `VcpuFd`.
@@ -1128,5 +1134,15 @@ mod tests {
         const PSTATE_REG_ID: u64 = 0x6030_0000_0010_0042;
         vcpu.set_one_reg(PSTATE_REG_ID, data)
             .expect("Failed to set pstate register");
+    }
+
+    #[test]
+    fn set_kvm_immediate_exit() {
+        let kvm = Kvm::new().unwrap();
+        let vm = kvm.create_vm().unwrap();
+        let vcpu = vm.create_vcpu(0).unwrap();
+        assert_eq!(vcpu.kvm_run_ptr.as_mut_ref().immediate_exit, 0);
+        vcpu.set_kvm_immediate_exit(1);
+        assert_eq!(vcpu.kvm_run_ptr.as_mut_ref().immediate_exit, 1);
     }
 }

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -109,7 +109,7 @@ impl VcpuFd {
     ///
     /// ```rust
     /// # extern crate kvm_ioctls;
-    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     /// let vcpu = vm.create_vcpu(0).unwrap();
@@ -140,7 +140,7 @@ impl VcpuFd {
     ///
     /// ```rust
     /// # extern crate kvm_ioctls;
-    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     /// let vcpu = vm.create_vcpu(0).unwrap();
@@ -175,7 +175,7 @@ impl VcpuFd {
     ///
     /// ```rust
     /// # extern crate kvm_ioctls;
-    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     /// let vcpu = vm.create_vcpu(0).unwrap();
@@ -207,7 +207,7 @@ impl VcpuFd {
     ///
     /// ```rust
     /// # extern crate kvm_ioctls;
-    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     /// let vcpu = vm.create_vcpu(0).unwrap();
@@ -241,7 +241,7 @@ impl VcpuFd {
     ///
     /// ```rust
     /// # extern crate kvm_ioctls;
-    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     /// let vcpu = vm.create_vcpu(0).unwrap();
@@ -275,7 +275,7 @@ impl VcpuFd {
     /// ```rust
     /// # extern crate kvm_ioctls;
     /// # extern crate kvm_bindings;
-    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// # use kvm_ioctls::Kvm;
     /// # use kvm_bindings::kvm_fpu;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -315,8 +315,7 @@ impl VcpuFd {
     ///  ```rust
     /// # extern crate kvm_ioctls;
     /// # extern crate kvm_bindings;
-    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd, MAX_KVM_CPUID_ENTRIES};
-    /// # use kvm_bindings::kvm_fpu;
+    /// # use kvm_ioctls::{Kvm, MAX_KVM_CPUID_ENTRIES};
     /// let kvm = Kvm::new().unwrap();
     /// let mut kvm_cpuid = kvm.get_supported_cpuid(MAX_KVM_CPUID_ENTRIES).unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -334,7 +333,7 @@ impl VcpuFd {
     ///     }
     /// }
     ///
-    /// vcpu.set_cpuid2(&kvm_cpuid);
+    /// vcpu.set_cpuid2(&kvm_cpuid).unwrap();
     /// ```
     ///
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -359,7 +358,7 @@ impl VcpuFd {
     ///
     /// ```rust
     /// # extern crate kvm_ioctls;
-    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     /// // For `get_lapic` to work, you first need to create a IRQ chip before creating the vCPU.
@@ -395,7 +394,7 @@ impl VcpuFd {
     ///
     /// ```rust
     /// # extern crate kvm_ioctls;
-    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// # use kvm_ioctls::Kvm;
     /// use std::io::Write;
     ///
     /// let kvm = Kvm::new().unwrap();
@@ -444,7 +443,7 @@ impl VcpuFd {
     /// ```rust
     /// # extern crate kvm_ioctls;
     /// # extern crate kvm_bindings;
-    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// # use kvm_ioctls::Kvm;
     /// # use kvm_bindings::kvm_msrs;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -478,7 +477,7 @@ impl VcpuFd {
     /// ```rust
     /// # extern crate kvm_ioctls;
     /// # extern crate kvm_bindings;
-    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// # use kvm_ioctls::Kvm;
     /// # use kvm_bindings::{kvm_msrs, kvm_msr_entry};
     /// # use std::mem;
     /// let kvm = Kvm::new().unwrap();
@@ -534,7 +533,7 @@ impl VcpuFd {
     /// ```rust
     /// # extern crate kvm_ioctls;
     /// # extern crate kvm_bindings;
-    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// # use kvm_ioctls::Kvm;
     /// use kvm_bindings::kvm_vcpu_init;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -594,7 +593,7 @@ impl VcpuFd {
     /// # use std::io::Write;
     /// # use std::ptr::null_mut;
     /// # use std::slice;
-    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd, VcpuExit};
+    /// # use kvm_ioctls::{Kvm, VcpuExit};
     /// # use kvm_bindings::{kvm_userspace_memory_region, KVM_MEM_LOG_DIRTY_PAGES};
     /// # let kvm = Kvm::new().unwrap();
     /// # let vm = kvm.create_vm().unwrap();

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -80,7 +80,7 @@ impl VmFd {
     /// # extern crate kvm_ioctls;
     /// extern crate kvm_bindings;
     ///
-    /// use kvm_ioctls::{Kvm, VmFd};
+    /// use kvm_ioctls::Kvm;
     /// use kvm_bindings::kvm_userspace_memory_region;
     ///
     /// let kvm = Kvm::new().unwrap();
@@ -121,7 +121,7 @@ impl VmFd {
     ///
     /// ```rust
     /// # extern crate kvm_ioctls;
-    /// # use kvm_ioctls::{Kvm, VmFd};
+    /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     /// vm.set_tss_address(0xfffb_d000).unwrap();
@@ -146,7 +146,7 @@ impl VmFd {
     ///
     /// ```rust
     /// # extern crate kvm_ioctls;
-    /// # use kvm_ioctls::{Kvm, VmFd};
+    /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     ///
@@ -181,7 +181,7 @@ impl VmFd {
     /// ```rust
     /// # extern crate kvm_ioctls;
     /// extern crate kvm_bindings;
-    /// # use kvm_ioctls::{Kvm, VmFd};
+    /// # use kvm_ioctls::Kvm;
     /// use kvm_bindings::kvm_pit_config;
     ///
     /// let kvm = Kvm::new().unwrap();
@@ -226,7 +226,7 @@ impl VmFd {
     /// ```rust
     /// # extern crate kvm_ioctls;
     /// extern crate kvm_bindings;
-    /// # use kvm_ioctls::{Kvm, VmFd};
+    /// # use kvm_ioctls::Kvm;
     /// use kvm_bindings::kvm_msi;
     ///
     /// let kvm = Kvm::new().unwrap();
@@ -273,7 +273,7 @@ impl VmFd {
     /// ```rust
     /// # extern crate kvm_ioctls;
     /// extern crate kvm_bindings;
-    /// # use kvm_ioctls::{Kvm, VmFd};
+    /// # use kvm_ioctls::Kvm;
     /// use kvm_bindings::kvm_irq_routing;
     ///
     /// let kvm = Kvm::new().unwrap();
@@ -320,7 +320,7 @@ impl VmFd {
     /// ```rust
     /// # extern crate kvm_ioctls;
     /// extern crate libc;
-    /// # use kvm_ioctls::{IoEventAddress, Kvm, NoDatamatch, VmFd};
+    /// # use kvm_ioctls::{IoEventAddress, Kvm, NoDatamatch};
     /// use libc::{eventfd, EFD_NONBLOCK};
     ///
     /// let kvm = Kvm::new().unwrap();
@@ -390,7 +390,7 @@ impl VmFd {
     /// # use std::io::Write;
     /// # use std::ptr::null_mut;
     /// # use std::slice;
-    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd, VcpuExit};
+    /// # use kvm_ioctls::{Kvm, VcpuExit};
     /// # use kvm_bindings::{kvm_userspace_memory_region, KVM_MEM_LOG_DIRTY_PAGES};
     /// # let kvm = Kvm::new().unwrap();
     /// # let vm = kvm.create_vm().unwrap();
@@ -504,7 +504,7 @@ impl VmFd {
     /// ```rust
     /// # extern crate kvm_ioctls;
     /// # extern crate libc;
-    /// # use kvm_ioctls::{Kvm, VmFd};
+    /// # use kvm_ioctls::Kvm;
     /// # use libc::{eventfd, EFD_NONBLOCK};
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -547,7 +547,7 @@ impl VmFd {
     /// ```rust
     /// # extern crate kvm_ioctls;
     /// # extern crate libc;
-    /// # use kvm_ioctls::{Kvm, VmFd};
+    /// # use kvm_ioctls::Kvm;
     /// # use libc::{eventfd, EFD_NONBLOCK};
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -599,7 +599,7 @@ impl VmFd {
     ///
     /// ```rust
     /// # extern crate kvm_ioctls;
-    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     /// // Create one vCPU with the ID=0.
@@ -665,7 +665,7 @@ impl VmFd {
     /// ```rust
     /// # extern crate kvm_ioctls;
     /// # extern crate kvm_bindings;
-    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// # use kvm_ioctls::Kvm;
     /// use kvm_bindings::{
     ///     kvm_device_type_KVM_DEV_TYPE_VFIO,
     ///     kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3,
@@ -713,7 +713,7 @@ impl VmFd {
     /// ```rust
     /// # extern crate kvm_ioctls;
     /// # extern crate kvm_bindings;
-    /// # use kvm_ioctls::{Kvm, VmFd, VcpuFd};
+    /// # use kvm_ioctls::Kvm;
     /// use kvm_bindings::kvm_vcpu_init;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -750,7 +750,7 @@ impl VmFd {
     /// # extern crate kvm_ioctls;
     /// extern crate kvm_bindings;
     ///
-    /// # use kvm_ioctls::{Cap, Kvm, VmFd};
+    /// # use kvm_ioctls::Kvm;
     /// use kvm_bindings::{kvm_enable_cap, KVM_CAP_SPLIT_IRQCHIP};
     ///
     /// let kvm = Kvm::new().unwrap();

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -4,30 +4,39 @@
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
-#![allow(unused)]
-use super::sys_ioctl::*;
+
+//! Declares necessary ioctls specific to their platform.
+
 use kvm_bindings::*;
 
-// Declares necessary ioctls specific to their platform.
+// Ioctls for /dev/kvm.
 
 ioctl_io_nr!(KVM_GET_API_VERSION, KVMIO, 0x00);
 ioctl_io_nr!(KVM_CREATE_VM, KVMIO, 0x01);
 ioctl_io_nr!(KVM_CHECK_EXTENSION, KVMIO, 0x03);
 ioctl_io_nr!(KVM_GET_VCPU_MMAP_SIZE, KVMIO, 0x04);
+/* Available with KVM_CAP_EXT_CPUID */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iowr_nr!(KVM_GET_SUPPORTED_CPUID, KVMIO, 0x05, kvm_cpuid2);
+/* Available with KVM_CAP_EXT_EMUL_CPUID */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iowr_nr!(KVM_GET_EMULATED_CPUID, KVMIO, 0x09, kvm_cpuid2);
+
+// Ioctls for VM fds.
+
 ioctl_io_nr!(KVM_CREATE_VCPU, KVMIO, 0x41);
 ioctl_iow_nr!(KVM_GET_DIRTY_LOG, KVMIO, 0x42, kvm_dirty_log);
+/* Available with KVM_CAP_USER_MEMORY */
 ioctl_iow_nr!(
     KVM_SET_USER_MEMORY_REGION,
     KVMIO,
     0x46,
     kvm_userspace_memory_region
 );
+/* Available with KVM_CAP_SET_TSS_ADDR */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_io_nr!(KVM_SET_TSS_ADDR, KVMIO, 0x47);
+/* Available with KVM_CAP_IRQCHIP */
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
@@ -36,6 +45,7 @@ ioctl_io_nr!(KVM_SET_TSS_ADDR, KVMIO, 0x47);
     target_arch = "s390"
 ))]
 ioctl_io_nr!(KVM_CREATE_IRQCHIP, KVMIO, 0x60);
+/* Available with KVM_CAP_IRQ_ROUTING */
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
@@ -43,6 +53,7 @@ ioctl_io_nr!(KVM_CREATE_IRQCHIP, KVMIO, 0x60);
     target_arch = "aarch64"
 ))]
 ioctl_iow_nr!(KVM_SET_GSI_ROUTING, KVMIO, 0x6a, kvm_irq_routing);
+/* Available with KVM_CAP_IRQFD */
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
@@ -51,9 +62,14 @@ ioctl_iow_nr!(KVM_SET_GSI_ROUTING, KVMIO, 0x6a, kvm_irq_routing);
     target_arch = "s390"
 ))]
 ioctl_iow_nr!(KVM_IRQFD, KVMIO, 0x76, kvm_irqfd);
+/* Available with KVM_CAP_PIT2 */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iow_nr!(KVM_CREATE_PIT2, KVMIO, 0x77, kvm_pit_config);
+/* Available with KVM_CAP_IOEVENTFD */
 ioctl_iow_nr!(KVM_IOEVENTFD, KVMIO, 0x79, kvm_ioeventfd);
+
+// Ioctls for VCPU fds.
+
 ioctl_io_nr!(KVM_RUN, KVMIO, 0x80);
 #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
 ioctl_ior_nr!(KVM_GET_REGS, KVMIO, 0x81, kvm_regs);
@@ -73,6 +89,7 @@ ioctl_ior_nr!(KVM_GET_SREGS, KVMIO, 0x83, kvm_sregs);
     target_arch = "powerpc64"
 ))]
 ioctl_iow_nr!(KVM_SET_SREGS, KVMIO, 0x84, kvm_sregs);
+/* Available with KVM_CAP_GET_MSR_FEATURES */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iowr_nr!(KVM_GET_MSR_INDEX_LIST, KVMIO, 0x02, kvm_msr_list);
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -80,17 +97,22 @@ ioctl_iowr_nr!(KVM_GET_MSRS, KVMIO, 0x88, kvm_msrs);
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iow_nr!(KVM_SET_MSRS, KVMIO, 0x89, kvm_msrs);
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-ioctl_iow_nr!(KVM_SET_CPUID2, KVMIO, 0x90, kvm_cpuid2);
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_ior_nr!(KVM_GET_FPU, KVMIO, 0x8c, kvm_fpu);
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iow_nr!(KVM_SET_FPU, KVMIO, 0x8d, kvm_fpu);
+/* Available with KVM_CAP_IRQCHIP */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_ior_nr!(KVM_GET_LAPIC, KVMIO, 0x8e, kvm_lapic_state);
+/* Available with KVM_CAP_IRQCHIP */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iow_nr!(KVM_SET_LAPIC, KVMIO, 0x8f, kvm_lapic_state);
+/* Available with KVM_CAP_EXT_CPUID */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_iow_nr!(KVM_SET_CPUID2, KVMIO, 0x90, kvm_cpuid2);
+/* Available with KVM_CAP_ENABLE_CAP */
 #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
 ioctl_iow_nr!(KVM_ENABLE_CAP, KVMIO, 0xa3, kvm_enable_cap);
+/* Available with KVM_CAP_SIGNAL_MSI */
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
@@ -98,13 +120,19 @@ ioctl_iow_nr!(KVM_ENABLE_CAP, KVMIO, 0xa3, kvm_enable_cap);
     target_arch = "aarch64"
 ))]
 ioctl_iow_nr!(KVM_SIGNAL_MSI, KVMIO, 0xa5, kvm_msi);
+/* Available with KVM_CAP_ONE_REG */
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 ioctl_iow_nr!(KVM_SET_ONE_REG, KVMIO, 0xac, kvm_one_reg);
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 ioctl_iow_nr!(KVM_ARM_VCPU_INIT, KVMIO, 0xae, kvm_vcpu_init);
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 ioctl_ior_nr!(KVM_ARM_PREFERRED_TARGET, KVMIO, 0xaf, kvm_vcpu_init);
+
+// Device ioctls.
+
+/* Available with KVM_CAP_DEVICE_CTRL */
 ioctl_iowr_nr!(KVM_CREATE_DEVICE, KVMIO, 0xe0, kvm_create_device);
+/* Available with KVM_CAP_VM_ATTRIBUTES */
 ioctl_iow_nr!(KVM_SET_DEVICE_ATTR, KVMIO, 0xe1, kvm_device_attr);
 
 #[cfg(test)]
@@ -114,6 +142,7 @@ mod tests {
 
     use libc::{c_char, open, O_RDWR};
 
+    use super::super::sys_ioctl::*;
     use super::*;
     const KVM_PATH: &'static str = "/dev/kvm\0";
 

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -25,6 +25,7 @@ ioctl_iowr_nr!(KVM_GET_EMULATED_CPUID, KVMIO, 0x09, kvm_cpuid2);
 // Ioctls for VM fds.
 
 ioctl_io_nr!(KVM_CREATE_VCPU, KVMIO, 0x41);
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iow_nr!(KVM_GET_DIRTY_LOG, KVMIO, 0x42, kvm_dirty_log);
 /* Available with KVM_CAP_USER_MEMORY */
 ioctl_iow_nr!(

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -68,6 +68,24 @@ ioctl_iow_nr!(KVM_IRQFD, KVMIO, 0x76, kvm_irqfd);
 ioctl_iow_nr!(KVM_CREATE_PIT2, KVMIO, 0x77, kvm_pit_config);
 /* Available with KVM_CAP_IOEVENTFD */
 ioctl_iow_nr!(KVM_IOEVENTFD, KVMIO, 0x79, kvm_ioeventfd);
+/* Available with KVM_CAP_IRQCHIP */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_iowr_nr!(KVM_GET_IRQCHIP, KVMIO, 0x62, kvm_irqchip);
+/* Available with KVM_CAP_IRQCHIP */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_ior_nr!(KVM_SET_IRQCHIP, KVMIO, 0x63, kvm_irqchip);
+/* Available with KVM_CAP_ADJUST_CLOCK */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_iow_nr!(KVM_SET_CLOCK, KVMIO, 0x7b, kvm_clock_data);
+/* Available with KVM_CAP_ADJUST_CLOCK */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_ior_nr!(KVM_GET_CLOCK, KVMIO, 0x7c, kvm_clock_data);
+/* Available with KVM_CAP_PIT_STATE2 */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_ior_nr!(KVM_GET_PIT2, KVMIO, 0x9f, kvm_pit_state2);
+/* Available with KVM_CAP_PIT_STATE2 */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_iow_nr!(KVM_SET_PIT2, KVMIO, 0xa0, kvm_pit_state2);
 
 // Ioctls for VCPU fds.
 

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -110,6 +110,52 @@ ioctl_iow_nr!(KVM_SET_LAPIC, KVMIO, 0x8f, kvm_lapic_state);
 /* Available with KVM_CAP_EXT_CPUID */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iow_nr!(KVM_SET_CPUID2, KVMIO, 0x90, kvm_cpuid2);
+/* Available with KVM_CAP_EXT_CPUID */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_iowr_nr!(KVM_GET_CPUID2, KVMIO, 0x91, kvm_cpuid2);
+/* Available with KVM_CAP_MP_STATE */
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "arm",
+    target_arch = "aarch64",
+    target_arch = "s390"
+))]
+ioctl_ior_nr!(KVM_GET_MP_STATE, KVMIO, 0x98, kvm_mp_state);
+/* Available with KVM_CAP_MP_STATE */
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "arm",
+    target_arch = "aarch64",
+    target_arch = "s390"
+))]
+ioctl_iow_nr!(KVM_SET_MP_STATE, KVMIO, 0x99, kvm_mp_state);
+/* Available with KVM_CAP_VCPU_EVENTS */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_ior_nr!(KVM_GET_VCPU_EVENTS, KVMIO, 0x9f, kvm_vcpu_events);
+/* Available with KVM_CAP_VCPU_EVENTS */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_iow_nr!(KVM_SET_VCPU_EVENTS, KVMIO, 0xa0, kvm_vcpu_events);
+/* Available with KVM_CAP_DEBUGREGS */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_ior_nr!(KVM_GET_DEBUGREGS, KVMIO, 0xa1, kvm_debugregs);
+/* Available with KVM_CAP_DEBUGREGS */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_iow_nr!(KVM_SET_DEBUGREGS, KVMIO, 0xa2, kvm_debugregs);
+/* Available with KVM_CAP_XSAVE */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_ior_nr!(KVM_GET_XSAVE, KVMIO, 0xa4, kvm_xsave);
+/* Available with KVM_CAP_XSAVE */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_iow_nr!(KVM_SET_XSAVE, KVMIO, 0xa5, kvm_xsave);
+/* Available with KVM_CAP_XCRS */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_ior_nr!(KVM_GET_XCRS, KVMIO, 0xa6, kvm_xcrs);
+/* Available with KVM_CAP_XCRS */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_iow_nr!(KVM_SET_XCRS, KVMIO, 0xa7, kvm_xcrs);
+
 /* Available with KVM_CAP_ENABLE_CAP */
 #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
 ioctl_iow_nr!(KVM_ENABLE_CAP, KVMIO, 0xa3, kvm_enable_cap);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ pub use ioctls::system::Kvm;
 pub use ioctls::vcpu::{VcpuExit, VcpuFd};
 pub use ioctls::vm::{IoEventAddress, NoDatamatch, VmFd};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub use ioctls::{CpuId, MAX_KVM_CPUID_ENTRIES};
+pub use ioctls::{CpuId, KVM_MAX_MSR_ENTRIES, MAX_KVM_CPUID_ENTRIES};
 // The following example is used to verify that our public
 // structures are exported properly.
 /// # Example


### PR DESCRIPTION
# Description of changes

- Slightly rearranged the list of supported `ioctl`s and grouped them in `system`, `vm` and `vcpu`.
- Added support to safely set the kvm vcpu `immediate_exit` flag. This can be used to kick vcpus out of `KVM_RUN`.
- Made a fix to `KVM_SET_MSRS` to propagate the return value which signifies the number of MSRs _successfully_ written.
- Added support for missing ioctls necessary for vcpu serialization and deserialization:
    - KVM_GET_CPUID2
    - KVM_GET_MP_STATE
    - KVM_SET_MP_STATE
    - KVM_GET_VCPU_EVENTS
    - KVM_SET_VCPU_EVENTS
    - KVM_GET_DEBUGREGS
    - KVM_SET_DEBUGREGS
    - KVM_GET_XSAVE
    - KVM_SET_XSAVE
    - KVM_GET_XCRS
    - KVM_SET_XCRS
- Added support for missing ioctls necessary for vm serialization and deserialization:
    - KVM_GET_IRQCHIP
    - KVM_SET_IRQCHIP
    - KVM_GET_PIT2
    - KVM_SET_PIT2
    - KVM_GET_CLOCK
    - KVM_SET_CLOCK