### PR TITLE
Implement MsrList and Msrs as FamStructWrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 Cargo.lock
 /target
+.idea
 **/*.rs.bk
 **/.pytest_cache/
 **/__pycache__/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 libc = ">=0.2.39"
-kvm-bindings = ">=0.1.0"
+kvm-bindings = { version = ">=0.2.0", features = ["fam-wrappers"] }
 vmm-sys-util = ">=0.1.1"
 
 [dev-dependencies]

--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 92.0,
+  "coverage_score": 91.9,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/ioctls/mod.rs
+++ b/src/ioctls/mod.rs
@@ -6,8 +6,6 @@
 // found in the THIRD-PARTY file.
 
 use std::io;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use std::mem::size_of;
 use std::os::unix::io::AsRawFd;
 use std::ptr::null_mut;
 use std::result;
@@ -28,39 +26,6 @@ pub mod vm;
 /// This typedef is generally used to avoid writing out io::Error directly and
 /// is otherwise a direct mapping to Result.
 pub type Result<T> = result::Result<T, io::Error>;
-
-// Returns a `Vec<T>` with a size in bytes at least as large as `size_in_bytes`.
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-fn vec_with_size_in_bytes<T: Default>(size_in_bytes: usize) -> Vec<T> {
-    let rounded_size = (size_in_bytes + size_of::<T>() - 1) / size_of::<T>();
-    let mut v = Vec::with_capacity(rounded_size);
-    for _ in 0..rounded_size {
-        v.push(T::default())
-    }
-    v
-}
-
-// The kvm API has many structs that resemble the following `Foo` structure:
-//
-// ```
-// #[repr(C)]
-// struct Foo {
-//    some_data: u32
-//    entries: __IncompleteArrayField<__u32>,
-// }
-// ```
-//
-// In order to allocate such a structure, `size_of::<Foo>()` would be too small because it would not
-// include any space for `entries`. To make the allocation large enough while still being aligned
-// for `Foo`, a `Vec<Foo>` is created. Only the first element of `Vec<Foo>` would actually be used
-// as a `Foo`. The remaining memory in the `Vec<Foo>` is for `entries`, which must be contiguous
-// with `Foo`. This function is used to make the `Vec<Foo>` with enough space for `count` entries.
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-fn vec_with_array_field<T: Default, F>(count: usize) -> Vec<T> {
-    let element_space = count * size_of::<F>();
-    let vec_size_bytes = size_of::<T>() + element_space;
-    vec_with_size_in_bytes(vec_size_bytes)
-}
 
 /// Safe wrapper over the `kvm_run` struct.
 ///

--- a/src/ioctls/system.rs
+++ b/src/ioctls/system.rs
@@ -14,12 +14,11 @@ use std::os::raw::{c_char, c_ulong};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 
 use cap::Cap;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use ioctls::vec_with_array_field;
 use ioctls::vm::{new_vmfd, VmFd};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use ioctls::CpuId;
 use ioctls::Result;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use kvm_bindings::CpuId;
 use kvm_ioctls::*;
 use vmm_sys_util::ioctl::{ioctl, ioctl_with_val};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -265,12 +264,14 @@ impl Kvm {
     /// # Example
     ///
     /// ```
-    /// use kvm_ioctls::{Kvm, MAX_KVM_CPUID_ENTRIES};
+    /// extern crate kvm_bindings;
+    /// use kvm_bindings::KVM_MAX_CPUID_ENTRIES;
+    /// use kvm_ioctls::Kvm;
     ///
     /// let kvm = Kvm::new().unwrap();
-    /// let mut cpuid = kvm.get_emulated_cpuid(MAX_KVM_CPUID_ENTRIES).unwrap();
+    /// let mut cpuid = kvm.get_emulated_cpuid(KVM_MAX_CPUID_ENTRIES).unwrap();
     /// let cpuid_entries = cpuid.as_mut_slice();
-    /// assert!(cpuid_entries.len() <= MAX_KVM_CPUID_ENTRIES);
+    /// assert!(cpuid_entries.len() <= KVM_MAX_CPUID_ENTRIES);
     /// ```
     ///
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -290,12 +291,14 @@ impl Kvm {
     /// # Example
     ///
     /// ```
-    /// use kvm_ioctls::{Kvm, MAX_KVM_CPUID_ENTRIES};
+    /// extern crate kvm_bindings;
+    /// use kvm_bindings::KVM_MAX_CPUID_ENTRIES;
+    /// use kvm_ioctls::Kvm;
     ///
     /// let kvm = Kvm::new().unwrap();
-    /// let mut cpuid = kvm.get_emulated_cpuid(MAX_KVM_CPUID_ENTRIES).unwrap();
+    /// let mut cpuid = kvm.get_emulated_cpuid(KVM_MAX_CPUID_ENTRIES).unwrap();
     /// let cpuid_entries = cpuid.as_mut_slice();
-    /// assert!(cpuid_entries.len() <= MAX_KVM_CPUID_ENTRIES);
+    /// assert!(cpuid_entries.len() <= KVM_MAX_CPUID_ENTRIES);
     /// ```
     ///
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -310,7 +313,7 @@ impl Kvm {
     /// # Example
     ///
     /// ```
-    /// use kvm_ioctls::{Kvm, MAX_KVM_CPUID_ENTRIES};
+    /// use kvm_ioctls::Kvm;
     ///
     /// let kvm = Kvm::new().unwrap();
     /// let msr_index_list = kvm.get_msr_index_list().unwrap();
@@ -406,9 +409,9 @@ impl FromRawFd for Kvm {
 mod tests {
     use super::*;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    use vmm_sys_util::fam::FamStruct;
+    use kvm_bindings::KVM_MAX_CPUID_ENTRIES;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    use MAX_KVM_CPUID_ENTRIES;
+    use vmm_sys_util::fam::FamStruct;
 
     #[test]
     fn test_kvm_new() {
@@ -454,20 +457,20 @@ mod tests {
     #[test]
     fn test_get_supported_cpuid() {
         let kvm = Kvm::new().unwrap();
-        let mut cpuid = kvm.get_supported_cpuid(MAX_KVM_CPUID_ENTRIES).unwrap();
+        let mut cpuid = kvm.get_supported_cpuid(KVM_MAX_CPUID_ENTRIES).unwrap();
         let cpuid_entries = cpuid.as_mut_slice();
         assert!(cpuid_entries.len() > 0);
-        assert!(cpuid_entries.len() <= MAX_KVM_CPUID_ENTRIES);
+        assert!(cpuid_entries.len() <= KVM_MAX_CPUID_ENTRIES);
     }
 
     #[test]
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn test_get_emulated_cpuid() {
         let kvm = Kvm::new().unwrap();
-        let mut cpuid = kvm.get_emulated_cpuid(MAX_KVM_CPUID_ENTRIES).unwrap();
+        let mut cpuid = kvm.get_emulated_cpuid(KVM_MAX_CPUID_ENTRIES).unwrap();
         let cpuid_entries = cpuid.as_mut_slice();
         assert!(cpuid_entries.len() > 0);
-        assert!(cpuid_entries.len() <= MAX_KVM_CPUID_ENTRIES);
+        assert!(cpuid_entries.len() <= KVM_MAX_CPUID_ENTRIES);
     }
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -480,10 +483,8 @@ mod tests {
         assert!(rawfd >= 0);
         let kvm = unsafe { Kvm::from_raw_fd(rawfd) };
 
-        let cpuid_1 = kvm.get_supported_cpuid(MAX_KVM_CPUID_ENTRIES).unwrap();
-        let mut cpuid_2 = cpuid_1.clone();
-        assert!(cpuid_1 == cpuid_2);
-        cpuid_2 = CpuId::new(cpuid_1.as_fam_struct_ref().len());
+        let cpuid_1 = kvm.get_supported_cpuid(KVM_MAX_CPUID_ENTRIES).unwrap();
+        let cpuid_2 = CpuId::new(cpuid_1.as_fam_struct_ref().len());
         assert!(cpuid_1 != cpuid_2);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,8 +192,6 @@ pub use ioctls::device::DeviceFd;
 pub use ioctls::system::Kvm;
 pub use ioctls::vcpu::{VcpuExit, VcpuFd};
 pub use ioctls::vm::{IoEventAddress, NoDatamatch, VmFd};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub use ioctls::{CpuId, KVM_MAX_MSR_ENTRIES, MAX_KVM_CPUID_ENTRIES};
 // The following example is used to verify that our public
 // structures are exported properly.
 /// # Example


### PR DESCRIPTION
# Description of changes

`kvm_msr_list` and `kvm_msrs` each contain a flexible array member and were forcing users of `kvm-ioctls` crate to work with `unsafe` code.
Use the `kvm-bindings` `CpuId`, `MsrList` and `Msrs` safe wrappers over them and change our ioctl functions to use these safe wrappers.