### PR TITLE
vcpu: Add wrapper for KVM_GET_ONE_REG.

### DIFF
--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -187,6 +187,8 @@ ioctl_iow_nr!(KVM_ENABLE_CAP, KVMIO, 0xa3, kvm_enable_cap);
 ioctl_iow_nr!(KVM_SIGNAL_MSI, KVMIO, 0xa5, kvm_msi);
 /* Available with KVM_CAP_ONE_REG */
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+ioctl_iow_nr!(KVM_GET_ONE_REG, KVMIO, 0xab, kvm_one_reg);
+#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 ioctl_iow_nr!(KVM_SET_ONE_REG, KVMIO, 0xac, kvm_one_reg);
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 ioctl_iow_nr!(KVM_ARM_VCPU_INIT, KVMIO, 0xae, kvm_vcpu_init);


### PR DESCRIPTION
- add ioctl definition in kvm_ioctls.rs
- implement vcpu.get_one_reg()
- enable KVM_GET_ONE_REG / KVM_SET_ONE_REG for all platforms.

Signed-off-by: Andrei Sandu <sandreim@amazon.com>