### PR TITLE
vm: Add a function to unregister ioeventfd

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 92.3,
+  "coverage_score": 92.5,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
The KVM_IOEVENTFD ioctl allows for both assigning and deassigning events
to a specific PIO or MMIO guest address. This commit introduces the
missing function to perform the deassignment.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>