### PR TITLE
use errno wrapper instead of io::Error in Result types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Unreleased
+
+## Changed
+- Now exporting kvm_ioctls::Error type definition so that users of this
+  crate can create their own wrapping errors without having to know the
+  Error type used internally by this crate.
+- No longer exporting kvm_ioctls::Result. Users of this crate should
+  not have to use kvm_ioctls::Result outside the crate.
+- kvm_ioctls::Error now works with errno::Error instead of io::Error.
+
 # v0.3.0
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0 OR MIT"
 [dependencies]
 libc = ">=0.2.39"
 kvm-bindings = { version = ">=0.2.0", features = ["fam-wrappers"] }
-vmm-sys-util = ">=0.1.1"
+vmm-sys-util = ">=0.2.1"
 
 [dev-dependencies]
 byteorder = ">=1.2.1"

--- a/src/ioctls/device.rs
+++ b/src/ioctls/device.rs
@@ -100,7 +100,7 @@ mod tests {
 
         let dist_attr = kvm_bindings::kvm_device_attr {
             group: KVM_DEV_VFIO_GROUP,
-            attr: KVM_DEV_VFIO_GROUP_ADD as u64,
+            attr: u64::from(KVM_DEV_VFIO_GROUP_ADD),
             addr: 0x0,
             flags: 0,
         };

--- a/src/ioctls/device.rs
+++ b/src/ioctls/device.rs
@@ -4,21 +4,11 @@
 use std::fs::File;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 
+use ioctls::Result;
 use kvm_bindings::kvm_device_attr;
-
 use kvm_ioctls::KVM_SET_DEVICE_ATTR;
 use vmm_sys_util::errno;
 use vmm_sys_util::ioctl::ioctl_with_ref;
-
-/// A specialized `Result` type for device KVM ioctls.
-///
-/// This typedef is generally used to avoid writing out errno::Error directly and
-/// is otherwise a direct mapping to Result.
-///
-/// This is temporary until all io::Errors have been converted to errno::Errors and will
-/// be removed in a later commit. I've chosen to temporarily add it so that each individual
-/// commit is buildable and functioning.
-pub type Result<T> = std::result::Result<T, errno::Error>;
 
 /// Wrapper over the file descriptor obtained when creating an emulated device in the kernel.
 pub struct DeviceFd {

--- a/src/ioctls/mod.rs
+++ b/src/ioctls/mod.rs
@@ -5,12 +5,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-use std::io;
 use std::os::unix::io::AsRawFd;
 use std::ptr::null_mut;
-use std::result;
 
 use kvm_bindings::kvm_run;
+use vmm_sys_util::errno;
 
 /// Wrappers over KVM device ioctls.
 pub mod device;
@@ -23,9 +22,9 @@ pub mod vm;
 
 /// A specialized `Result` type for KVM ioctls.
 ///
-/// This typedef is generally used to avoid writing out io::Error directly and
+/// This typedef is generally used to avoid writing out errno::Error directly and
 /// is otherwise a direct mapping to Result.
-pub type Result<T> = result::Result<T, io::Error>;
+pub type Result<T> = std::result::Result<T, errno::Error>;
 
 /// Safe wrapper over the `kvm_run` struct.
 ///
@@ -64,7 +63,7 @@ impl KvmRunWrapper {
             )
         };
         if addr == libc::MAP_FAILED {
-            return Err(io::Error::last_os_error());
+            return Err(errno::Error::last());
         }
 
         Ok(KvmRunWrapper {

--- a/src/ioctls/mod.rs
+++ b/src/ioctls/mod.rs
@@ -49,7 +49,7 @@ impl KvmRunWrapper {
     /// # Arguments
     /// * `fd` - File descriptor to mmap from.
     /// * `size` - Size of memory region in bytes.
-    pub fn mmap_from_fd(fd: &AsRawFd, size: usize) -> Result<KvmRunWrapper> {
+    pub fn mmap_from_fd(fd: &dyn AsRawFd, size: usize) -> Result<KvmRunWrapper> {
         // This is safe because we are creating a mapping in a place not already used by any other
         // area in this process.
         let addr = unsafe {

--- a/src/ioctls/system.rs
+++ b/src/ioctls/system.rs
@@ -446,7 +446,7 @@ mod tests {
         let kvm = Kvm::new().unwrap();
         let mut cpuid = kvm.get_supported_cpuid(KVM_MAX_CPUID_ENTRIES).unwrap();
         let cpuid_entries = cpuid.as_mut_slice();
-        assert!(cpuid_entries.len() > 0);
+        assert!(!cpuid_entries.is_empty());
         assert!(cpuid_entries.len() <= KVM_MAX_CPUID_ENTRIES);
     }
 
@@ -456,7 +456,7 @@ mod tests {
         let kvm = Kvm::new().unwrap();
         let mut cpuid = kvm.get_emulated_cpuid(KVM_MAX_CPUID_ENTRIES).unwrap();
         let cpuid_entries = cpuid.as_mut_slice();
-        assert!(cpuid_entries.len() > 0);
+        assert!(!cpuid_entries.is_empty());
         assert!(cpuid_entries.len() <= KVM_MAX_CPUID_ENTRIES);
     }
 

--- a/src/ioctls/system.rs
+++ b/src/ioctls/system.rs
@@ -11,6 +11,7 @@ use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 
 use cap::Cap;
 use ioctls::vm::{new_vmfd, VmFd};
+use ioctls::Result;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use kvm_bindings::{CpuId, MsrList, KVM_MAX_MSR_ENTRIES};
 use kvm_ioctls::*;
@@ -18,16 +19,6 @@ use vmm_sys_util::errno;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use vmm_sys_util::ioctl::ioctl_with_mut_ptr;
 use vmm_sys_util::ioctl::{ioctl, ioctl_with_val};
-
-/// A specialized `Result` type for system KVM ioctls.
-///
-/// This typedef is generally used to avoid writing out errno::Error directly and
-/// is otherwise a direct mapping to Result.
-///
-/// This is temporary until all io::Errors have been converted to errno::Errors and will
-/// be removed in a later commit. I've chosen to temporarily add it so that each individual
-/// commit is buildable and functioning.
-pub type Result<T> = std::result::Result<T, errno::Error>;
 
 /// Wrapper over KVM system ioctls.
 pub struct Kvm {

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -1203,7 +1203,7 @@ mod tests {
             panic!("mmap failed.");
         }
 
-        return addr as *mut u8;
+        addr as *mut u8
     }
 
     #[test]
@@ -1443,7 +1443,7 @@ mod tests {
             // Get a mutable slice of `mem_size` from `load_addr`.
             // This is safe because we mapped it before.
             let mut slice = std::slice::from_raw_parts_mut(load_addr, mem_size);
-            slice.write(&code).unwrap();
+            slice.write_all(&code).unwrap();
         }
 
         let vcpu_fd = vm.create_vcpu(0).unwrap();
@@ -1488,10 +1488,10 @@ mod tests {
                     // * one when the code itself is loaded in memory;
                     // * and one more from the `movl` that writes to address 0x8000
                     let dirty_pages_bitmap = vm.get_dirty_log(slot, mem_size).unwrap();
-                    let dirty_pages = dirty_pages_bitmap
+                    let dirty_pages: u32 = dirty_pages_bitmap
                         .into_iter()
                         .map(|page| page.count_ones())
-                        .fold(0, |dirty_page_count, i| dirty_page_count + i);
+                        .sum();
                     assert_eq!(dirty_pages, 2);
                     break;
                 }
@@ -1573,10 +1573,7 @@ mod tests {
             badf_errno
         );
         assert_eq!(
-            faulty_vcpu_fd
-                .set_msrs(&mut Msrs::new(1))
-                .unwrap_err()
-                .errno(),
+            faulty_vcpu_fd.set_msrs(&Msrs::new(1)).unwrap_err().errno(),
             badf_errno
         );
         assert_eq!(

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -10,7 +10,7 @@ use libc::EINVAL;
 use std::fs::File;
 use std::os::unix::io::{AsRawFd, RawFd};
 
-use ioctls::KvmRunWrapper;
+use ioctls::{KvmRunWrapper, Result};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use kvm_bindings::{CpuId, Msrs};
 use kvm_ioctls::*;
@@ -18,16 +18,6 @@ use vmm_sys_util::errno;
 use vmm_sys_util::ioctl::{ioctl, ioctl_with_mut_ref, ioctl_with_ref};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use vmm_sys_util::ioctl::{ioctl_with_mut_ptr, ioctl_with_ptr};
-
-/// A specialized `Result` type for vcpu KVM ioctls.
-///
-/// This typedef is generally used to avoid writing out errno::Error directly and
-/// is otherwise a direct mapping to Result.
-///
-/// This is temporary until all io::Errors have been converted to errno::Errors and will
-/// be removed in a later commit. I've chosen to temporarily add it so that each individual
-/// commit is buildable and functioning.
-pub type Result<T> = std::result::Result<T, errno::Error>;
 
 /// Reasons for vCPU exits.
 ///

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -16,21 +16,11 @@ use ioctls::device::new_device;
 use ioctls::device::DeviceFd;
 use ioctls::vcpu::new_vcpu;
 use ioctls::vcpu::VcpuFd;
-use ioctls::KvmRunWrapper;
+use ioctls::{KvmRunWrapper, Result};
 use kvm_ioctls::*;
 use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::ioctl::{ioctl, ioctl_with_mut_ref, ioctl_with_ref, ioctl_with_val};
-
-/// A specialized `Result` type for vm KVM ioctls.
-///
-/// This typedef is generally used to avoid writing out errno::Error directly and
-/// is otherwise a direct mapping to Result.
-///
-/// This is temporary until all io::Errors have been converted to errno::Errors and will
-/// be removed in a later commit. I've chosen to temporarily add it so that each individual
-/// commit is buildable and functioning.
-pub type Result<T> = std::result::Result<T, errno::Error>;
 
 /// An address either in programmable I/O space or in memory mapped I/O space.
 ///

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -211,7 +211,7 @@ mod tests {
     use vmm_sys_util::ioctl::{ioctl, ioctl_with_val};
 
     use super::*;
-    const KVM_PATH: &'static str = "/dev/kvm\0";
+    const KVM_PATH: &str = "/dev/kvm\0";
 
     #[test]
     fn get_version() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,7 @@ pub use ioctls::vm::{IoEventAddress, NoDatamatch, VmFd};
 ///
 /// ```
 /// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-/// use kvm_ioctls::{KvmRunWrapper, Result};
+/// use kvm_ioctls::{KvmRunWrapper, Error};
 /// ```
-pub use ioctls::{KvmRunWrapper, Result};
+pub use ioctls::KvmRunWrapper;
+pub use vmm_sys_util::errno::Error;


### PR DESCRIPTION
Because io::Error type can have an ErrorKind that is meaningless to a vmm, a simple errno wrapper is preferred. Occasionally, the io::Error function that converts an errno to ErrorKind has some surprising mappings, although many of them simply map to Other, so I wish to sidestep the problem entirely.

For display purposes, the Display impl can simply pass through to io::Error, which does have a useful Display impl for any relevant errno.

Fixes #35 