### PR TITLE
Enable KVM_SET/GET_VCPU_EVENTS ioctls for Aarch64.

### DIFF
--- a/src/cap.rs
+++ b/src/cap.rs
@@ -62,7 +62,12 @@ pub enum Cap {
     XenHvm = KVM_CAP_XEN_HVM,
     AdjustClock = KVM_CAP_ADJUST_CLOCK,
     InternalErrorData = KVM_CAP_INTERNAL_ERROR_DATA,
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "arm",
+        target_arch = "aarch64"
+    ))]
     VcpuEvents = KVM_CAP_VCPU_EVENTS,
     S390Psw = KVM_CAP_S390_PSW,
     PpcSegstate = KVM_CAP_PPC_SEGSTATE,

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -150,10 +150,20 @@ ioctl_ior_nr!(KVM_GET_MP_STATE, KVMIO, 0x98, kvm_mp_state);
 ))]
 ioctl_iow_nr!(KVM_SET_MP_STATE, KVMIO, 0x99, kvm_mp_state);
 /* Available with KVM_CAP_VCPU_EVENTS */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "arm",
+    target_arch = "aarch64"
+))]
 ioctl_ior_nr!(KVM_GET_VCPU_EVENTS, KVMIO, 0x9f, kvm_vcpu_events);
 /* Available with KVM_CAP_VCPU_EVENTS */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "arm",
+    target_arch = "aarch64"
+))]
 ioctl_iow_nr!(KVM_SET_VCPU_EVENTS, KVMIO, 0xa0, kvm_vcpu_events);
 /* Available with KVM_CAP_DEBUGREGS */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]


### PR DESCRIPTION
Enable KVM_SET/GET_VCPU_EVENTS ioctls for Aarch64.

KVM_GET_VCPU_EVENTS and KVM_SET_VCPU_EVENTS ioctls have been supported
on Aarch64 from a recent kernel version.
This patch enables them on Aarch64 and checked cap KVM_CAP_VCPU_EVENTS
before calling them in test code to avoid error in old kernel.

Signed-off-by: Michael Zhao <michael.zhao@arm.com>