### PR TITLE
Add ioctl KVM_IRQ_LINE from CrosVM to rust-vmm

### DIFF
--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -46,6 +46,14 @@ ioctl_io_nr!(KVM_SET_TSS_ADDR, KVMIO, 0x47);
     target_arch = "s390"
 ))]
 ioctl_io_nr!(KVM_CREATE_IRQCHIP, KVMIO, 0x60);
+/* Available with KVM_CAP_IRQCHIP */
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "arm",
+    target_arch = "aarch64"
+))]
+ioctl_iow_nr!(KVM_IRQ_LINE, KVMIO, 0x61, kvm_irq_level);
 /* Available with KVM_CAP_IRQ_ROUTING */
 #[cfg(any(
     target_arch = "x86",


### PR DESCRIPTION
As CrosVM has the ioctl `KVM_IRQ_LINE` and referencing issue #11 , this PR proposes a design for implementation and test for ioctl `KVM_IRQ_LINE`.

I think following the coding style in [vm.rs](https://github.com/rust-vmm/kvm-ioctls/blob/master/src/ioctls/vm.rs), we also need to add an example for this ioctl, however it seems that how to use this ioctl differs (a lot) between different machine architectures. Therefore I would like to get some comments about how we can write the example. Thanks! 

Signed-off-by: Henry Wang <<henry.wang@arm.com>>