### PR TITLE
vcpu: Add the system-level event type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,7 @@ mod ioctls;
 pub use cap::Cap;
 pub use ioctls::device::DeviceFd;
 pub use ioctls::system::Kvm;
-pub use ioctls::vcpu::{VcpuExit, VcpuFd};
+pub use ioctls::vcpu::{SystemEventType, VcpuExit, VcpuFd};
 pub use ioctls::vm::{IoEventAddress, NoDatamatch, VmFd};
 // The following example is used to verify that our public
 // structures are exported properly.


### PR DESCRIPTION
This newly added KVM_EXIT_SYSTEM_EVENT type will be used by KVM
ARM/ARM64 in-kernel PSCI v0.2 support to reset/shutdown VMs.

Signed-off-by: Xu Yandong <xuyandong2@huawei.com>