### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.5.0
+
+## Added
+- Support for the vcpu ioctls `KVM_GET/SET_VCPU_EVENTS` and `KVM_GET_DIRTY_LOG`
+  on `aarch64`.
+- Support for the vcpu ioctl `KVM_IRQ_LINE`.
+
 # v0.4.0
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvm-ioctls"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Amazon Firecracker Team <firecracker-maintainers@amazon.com>"]
 description = "Safe wrappers over KVM ioctls"
 repository = "https://github.com/rust-vmm/kvm-ioctls"


### PR DESCRIPTION
A new `kvm-ioctls` version should export the 4 newly added ioctls (3 added on `aarch64` and previously present on `x86_64`; one new on both platforms).