### PR TITLE
vm: add wrapper for `KVM_SET_IDENTITY_MAP_ADDR`

### DIFF
--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -36,6 +36,9 @@ ioctl_iow_nr!(
 /* Available with KVM_CAP_SET_TSS_ADDR */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_io_nr!(KVM_SET_TSS_ADDR, KVMIO, 0x47);
+/* Available with KVM_CAP_SET_IDENTITY_MAP_ADDR */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_iow_nr!(KVM_SET_IDENTITY_MAP_ADDR, KVMIO, 0x48, u64);
 /* Available with KVM_CAP_IRQCHIP */
 #[cfg(any(
     target_arch = "x86",


### PR DESCRIPTION
This PR adds a wrapper for the `KVM_SET_IDENTITY_MAP_ADDR` ioctl. While it is no longer needed to call it for a vm to run successfully thanks to the kernel giving a sane default value, I think this should be in the crate for completeness.

Signed-off-by: Guillaume Pagnoux <guillaume.pagnoux@lse.epita.fr>