### PR TITLE
update rust-vmm-ci

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.9,
+  "coverage_score": 92.0,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -1326,9 +1326,7 @@ mod tests {
         let mut irqchip = kvm_irqchip::default();
         irqchip.chip_id = KVM_IRQCHIP_PIC_MASTER;
         // Set the irq_base to a non-default value to check that set & get work.
-        unsafe {
-            irqchip.chip.pic.irq_base = 10;
-        }
+        irqchip.chip.pic.irq_base = 10;
         assert!(vm.set_irqchip(&irqchip).is_ok());
 
         // We initialize a dummy irq chip (`other_irqchip`) in which the


### PR DESCRIPTION
Use the latest rust-vmm-ci and fix the warnings generated by switching to Rust 1.39.

Weirdly the coverage also needs to be updated.