### PR TITLE
Add support for KVM_HAS_DEVICE_ATTR ioctl.

### DIFF
--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 76.3,
+  "coverage_score": 76.5,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 92.1,
+  "coverage_score": 92.0,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -216,8 +216,10 @@ ioctl_ior_nr!(KVM_ARM_PREFERRED_TARGET, KVMIO, 0xaf, kvm_vcpu_init);
 
 /* Available with KVM_CAP_DEVICE_CTRL */
 ioctl_iowr_nr!(KVM_CREATE_DEVICE, KVMIO, 0xe0, kvm_create_device);
-/* Available with KVM_CAP_VM_ATTRIBUTES */
+/* Available with KVM_CAP_DEVICE_CTRL */
 ioctl_iow_nr!(KVM_SET_DEVICE_ATTR, KVMIO, 0xe1, kvm_device_attr);
+/* Available with KVM_CAP_DEVICE_CTRL */
+ioctl_iow_nr!(KVM_HAS_DEVICE_ATTR, KVMIO, 0xe3, kvm_device_attr);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Fixes https://github.com/rust-vmm/kvm-ioctls/issues/88.

Following modifications are included:
1. Add the wrapper for KVM_HAS_DEVICE_ATTR ioctl.
2. Update the test case of VGIC.
3. Add an example to show the usage of KVM_HAS_DEVICE_ATTR together
with KVM_SET_DEVICE_ATTR.

Signed-off-by: Michael Zhao <michael.zhao@arm.com>