### PR TITLE
vcpu: expose type and flags on KVM_EXIT_SYSTEM_EVENT

### DIFF
--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 76.5,
+  "coverage_score": 77.2,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 92.0,
+  "coverage_score": 91.3,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
#81 does not expose `flags`. Also, I add a test case for aarch64. This feature is required to support PSCI based shutdown and reboot on ARM. I can not add a test case for x86_64 since it is not used on x86_64 by default.