### PR TITLE
Add support for the KVM_KVMCLOCK_CTRL ioctl

### DIFF
--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -1009,6 +1009,18 @@ impl VcpuFd {
         Ok(reg_value)
     }
 
+    /// Signals to the host that the running VCPU is being paused by userspace.
+    ///
+    /// Supported on architectures that implement a paravirt clock (currently x86 only)
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    pub fn kvmclock_ctl(&self) -> Result<()> {
+        let ret = unsafe { ioctl(self, KVM_KVMCLOCK_CTRL()) };
+        if ret != 0 {
+            return Err(errno::Error::last());
+        }
+        Ok(())
+    }
+
     /// Triggers the running of the current virtual CPU returning an exit reason.
     ///
     /// See documentation for `KVM_RUN`.

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -190,6 +190,9 @@ ioctl_ior_nr!(KVM_GET_XCRS, KVMIO, 0xa6, kvm_xcrs);
 /* Available with KVM_CAP_XCRS */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iow_nr!(KVM_SET_XCRS, KVMIO, 0xa7, kvm_xcrs);
+/* Available with KVM_CAP_KVMCLOCK_CTRL */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_io_nr!(KVM_KVMCLOCK_CTRL, KVMIO, 0xad);
 
 /* Available with KVM_CAP_ENABLE_CAP */
 #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]


### PR DESCRIPTION
Hello,

I added the KVM_KVMCLOCK_CTRL ioctl. This would be useful for implementing suspend/resume in a VMM. 

I left this as a draft because I'm not sure what the best way to test this API would be. Thoughts?