### PR TITLE
Add support to get Host_IPA_Limit for AArch64

### DIFF
--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 76.2,
+  "coverage_score": 76.9,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -140,4 +140,5 @@ pub enum Cap {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     SplitIrqchip = KVM_CAP_SPLIT_IRQCHIP,
     ImmediateExit = KVM_CAP_IMMEDIATE_EXIT,
+    ArmVmIPASize = KVM_CAP_ARM_VM_IPA_SIZE,
 }


### PR DESCRIPTION
This commit adds support for getting Host_IPA_Limit for AArch64. This is useful when building VMM memory manager using rust-vmm.

Host_IPA_Limit is the maximum possible value for IPA_Bits on the host and is dependent on the CPU capability and the kernel configuration. The limit can be retrieved using KVM_CAP_ARM_VM_IPA_SIZE of the KVM_CHECK_EXTENSION ioctl.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>