### PR TITLE
Update README to use a Docker image matching the one used in CI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ docker run --device=/dev/kvm \
            -it \
            --security-opt seccomp=unconfined \
            --volume $(pwd)/kvm-ioctls:/kvm-ioctls \
-           rustvmm/dev:v2
+           rustvmm/dev:v5
 cd kvm-ioctls/
 cargo test
 ```


### PR DESCRIPTION
The local test reproduction on docker, as specified in the [README](https://github.com/rust-vmm/kvm-ioctls/blob/master/README.md), fails currently with the following error: 

error[E0133]: access to union field is unsafe and requires unsafe function or block
    --> src/ioctls/vm.rs:1331:9
     |
1331 |         irqchip.chip.pic.irq_base = 10;
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ access to union field
     |
     = note: the field may not be properly initialized: using uninitialized data will cause undefined behavior

This PR fixes the local test failure by appropriately marking the code as unsafe.