### PR TITLE
Support `datamatch` when unregister ioevent

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.3,
+  "coverage_score": 91.4,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
Whe unregistering an ioevent, the `datamatch` field should be set
correctly, otherwise it may unregister undesired ioevent.

Signed-off-by: Jason Cai (Xiang Feng) <xiangfeng.cai@alibaba-inc.com>
Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>