### PR TITLE
Add support to flexibly configure AArch64 IPA size of the guest

### DIFF
--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 76.9,
+  "coverage_score": 77.1,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
As `KVM_CREATE_VM` ioctl supports configuration of AArch64 IPA size of the guest after kernel v4.20, this commit adds support to flexibly configure AArch64 IPA size of the guest in rust-vmm.

Signed-off-by: Henry Wang <<Henry.Wang@arm.com>>