### PR TITLE
Add capability definition for KVM_CAP_MSI_DEVID

### DIFF
--- a/src/cap.rs
+++ b/src/cap.rs
@@ -141,4 +141,5 @@ pub enum Cap {
     SplitIrqchip = KVM_CAP_SPLIT_IRQCHIP,
     ImmediateExit = KVM_CAP_IMMEDIATE_EXIT,
     ArmVmIPASize = KVM_CAP_ARM_VM_IPA_SIZE,
+    MsiDevid = KVM_CAP_MSI_DEVID,
 }


### PR DESCRIPTION
The per-VM KVM_CAP_MSI_DEVID capability advertises the requirement to
provide the device ID in kvm_irq_routing_msi.

Signed-off-by: Michael Zhao <michael.zhao@arm.com>