### PR TITLE
Implement 'check_extension()' for Vm

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.3,
+  "coverage_score": 91.4,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
We have defined `check_extension()` in `Kvm` to perform `KVM_CHECK_EXTENSION` ioctl. While the same API is also needed in `Vm`.

One example of such extensions is `KVM_CAP_MSI_DEVID`. After adding Cap `KVM_CAP_MSI_DEVID` with https://github.com/rust-vmm/kvm-ioctls/pull/102, I realized it need to be checked against `Vm` rather than `Kvm`, but we haven't defined the API to do it.