### PR TITLE
Add support for `KVM_GET_REG_LIST` ioctl

### DIFF
--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -211,6 +211,8 @@ ioctl_iow_nr!(KVM_SET_ONE_REG, KVMIO, 0xac, kvm_one_reg);
 ioctl_iow_nr!(KVM_ARM_VCPU_INIT, KVMIO, 0xae, kvm_vcpu_init);
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 ioctl_ior_nr!(KVM_ARM_PREFERRED_TARGET, KVMIO, 0xaf, kvm_vcpu_init);
+#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+ioctl_iowr_nr!(KVM_GET_REG_LIST, KVMIO, 0xb0, kvm_reg_list);
 
 // Device ioctls.
 


### PR DESCRIPTION
The `KVM_GET_REG_LIST` ioctl is used to extract
a list containing the id of all registers on aarch64 architecture.
We need this in order to be able to save/restore them.

Fixes: https://github.com/rust-vmm/kvm-ioctls/issues/104

Signed-off-by: Diana Popa <dpopa@amazon.com>