### PR TITLE
Yet another dummy PR

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "rust-vmm-ci"]
 	path = rust-vmm-ci
-	url = https://github.com/rust-vmm/rust-vmm-ci.git
+	url = https://github.com/lauralt/rust-vmm-ci.git
+	branch = format_commit_2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,3 +235,5 @@ pub use ioctls::KvmRunWrapper;
 pub use vmm_sys_util::errno::Error;
 
 //bla
+//bla
+//

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,4 +236,4 @@ pub use vmm_sys_util::errno::Error;
 
 //bla
 //bla
-//
+//bla

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,3 +233,5 @@ pub use ioctls::vm::{IoEventAddress, NoDatamatch, VmFd};
 /// ```
 pub use ioctls::KvmRunWrapper;
 pub use vmm_sys_util::errno::Error;
+
+//bla


### PR DESCRIPTION

https://github.com/rust-vmm/linux-loader/pull/46 is failing the commit format test because of an older commit, unrelated to PR's commits. Opened this PR to confirm/infirm some beliefs.
Sorry for spamming!