### PR TITLE
Add support for KVM_SET_GUEST_DEBUG ioctl call

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.1,
+  "coverage_score": 91.2,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -217,6 +217,9 @@ ioctl_ior_nr!(KVM_ARM_PREFERRED_TARGET, KVMIO, 0xaf, kvm_vcpu_init);
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 ioctl_iowr_nr!(KVM_GET_REG_LIST, KVMIO, 0xb0, kvm_reg_list);
 
+/* Available with KVM_CAP_SET_GUEST_DEBUG */
+ioctl_iow_nr!(KVM_SET_GUEST_DEBUG, KVMIO, 0x9b, kvm_guest_debug);
+
 // Device ioctls.
 
 /* Available with KVM_CAP_DEVICE_CTRL */


### PR DESCRIPTION
This enables us to handle software breakpoints, perform single-stepping and possibly, implement hardware breakpoints