### PR TITLE
Add Safety heading to from_raw_fd docs

### DIFF
--- a/src/ioctls/device.rs
+++ b/src/ioctls/device.rs
@@ -164,7 +164,9 @@ impl AsRawFd for DeviceFd {
 }
 
 impl FromRawFd for DeviceFd {
-    /// This function is also unsafe as the primitives currently returned have the contract that
+    /// # Safety
+    ///
+    /// This function is unsafe as the primitives currently returned have the contract that
     /// they are the sole owner of the file descriptor they are wrapping. Usage of this function
     /// could accidentally allow violating this contract which can cause memory unsafety in code
     /// that relies on it being true.


### PR DESCRIPTION
Adds a `# Safety` heading to one function. And remove the word "also".