### PR TITLE
Fix broken tests on aarch64. #89

### DIFF
--- a/src/ioctls/device.rs
+++ b/src/ioctls/device.rs
@@ -260,6 +260,10 @@ mod tests {
 
         let device_fd = create_gic_device(&vm, 0);
 
+        // GICv3 on arm/aarch64 requires an online vCPU prior to setting device attributes,
+        // see: https://www.kernel.org/doc/html/latest/virt/kvm/devices/arm-vgic-v3.html
+        vm.create_vcpu(0).unwrap();
+
         // Following lines to re-construct device_fd are used to test
         // DeviceFd::from_raw_fd() and DeviceFd::as_raw_fd().
         let raw_fd = unsafe { libc::dup(device_fd.as_raw_fd()) };

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -1556,6 +1556,10 @@ mod tests {
         // Create the vGIC device.
         let vgic_fd = create_gic_device(&vm_fd, 0);
 
+        // GICv3 on arm/aarch64 requires an online vCPU prior to setting device attributes,
+        // see: https://www.kernel.org/doc/html/latest/virt/kvm/devices/arm-vgic-v3.html
+        vm_fd.create_vcpu(0).unwrap();
+
         // Set supported number of IRQs.
         set_supported_nr_irqs(&vgic_fd, 128);
         // Request the initialization of the vGIC.


### PR DESCRIPTION
This PR fixes two broken tests on `aarch64`:

* https://github.com/rust-vmm/kvm-ioctls/blob/2ac3adc8606c3e96d83935a707943014d8080e5b/src/ioctls/device.rs#L242
* https://github.com/rust-vmm/kvm-ioctls/blob/2ac3adc8606c3e96d83935a707943014d8080e5b/src/ioctls/vm.rs#L1523

There's still one broken test **on my machine** (old kernel) in `test_set_gsi_routing`, but I think it's unrelated to my [comment in #89](https://github.com/rust-vmm/kvm-ioctls/issues/89#issuecomment-740703396). ~~I'm looking into that one now.~~