### PR TITLE
vm: `create_vcpu` takes `u64` argument #123

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.2,
+  "coverage_score": 91.3,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -97,6 +97,7 @@ pub enum Cap {
     PpcSmt = KVM_CAP_PPC_SMT,
     PpcRma = KVM_CAP_PPC_RMA,
     MaxVcpus = KVM_CAP_MAX_VCPUS,
+    MaxVcpuId = KVM_CAP_MAX_VCPU_ID,
     PpcHior = KVM_CAP_PPC_HIOR,
     PpcPapr = KVM_CAP_PPC_PAPR,
     SwTlb = KVM_CAP_SW_TLB,

--- a/src/ioctls/system.rs
+++ b/src/ioctls/system.rs
@@ -227,6 +227,27 @@ impl Kvm {
         }
     }
 
+    /// Gets the Maximum VCPU ID per VM.
+    ///
+    /// See the documentation for `KVM_CAP_MAX_VCPU_ID`
+    /// Returns [get_max_vcpus()](struct.Kvm.html#method.get_max_vcpus) when
+    /// `KVM_CAP_MAX_VCPU_ID` is not implemented
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use kvm_ioctls::Kvm;
+    /// let kvm = Kvm::new().unwrap();
+    /// assert!(kvm.get_max_vcpu_id() > 0);
+    /// ```
+    ///
+    pub fn get_max_vcpu_id(&self) -> usize {
+        match self.check_extension_int(Cap::MaxVcpuId) {
+            0 => self.get_max_vcpus(),
+            x => x as usize,
+        }
+    }
+
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn get_cpuid(&self, kind: u64, num_entries: usize) -> Result<CpuId> {
         if num_entries > KVM_MAX_CPUID_ENTRIES {

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -1411,7 +1411,7 @@ mod tests {
             assert!(ncpuids <= KVM_MAX_CPUID_ENTRIES);
             let nr_vcpus = kvm.get_nr_vcpus();
             for cpu_idx in 0..nr_vcpus {
-                let vcpu = vm.create_vcpu(cpu_idx as u8).unwrap();
+                let vcpu = vm.create_vcpu(cpu_idx as u64).unwrap();
                 vcpu.set_cpuid2(&cpuid).unwrap();
                 let retrieved_cpuid = vcpu.get_cpuid2(ncpuids).unwrap();
                 // Only check the first few leafs as some (e.g. 13) are reserved.
@@ -1443,7 +1443,7 @@ mod tests {
             assert!(ncpuids <= KVM_MAX_CPUID_ENTRIES);
             let nr_vcpus = kvm.get_nr_vcpus();
             for cpu_idx in 0..nr_vcpus {
-                let vcpu = vm.create_vcpu(cpu_idx as u8).unwrap();
+                let vcpu = vm.create_vcpu(cpu_idx as u64).unwrap();
                 vcpu.set_cpuid2(&cpuid).unwrap();
                 let err = vcpu.get_cpuid2(ncpuids - 1 as usize).err();
                 assert_eq!(err.unwrap().errno(), libc::E2BIG);


### PR DESCRIPTION
Changed the passed parameter type from `u8` to `u64`, which the
underlying `ioctl` uses.

Added a missing cap `MaxVcpuId` (It is defined in kvm-bindings for both
arm* and x86* but was missing inside cap.rs. This was required by a test
case.)

Added a test case to assert failure if we pass parameter higher than the
`max_vcpu_id`.

Signed-off-by: Abhijit Gadgil <gabhijit@iitbombay.org>