### PR TITLE
kvm_ioctls: Add ioctl number for KVM_MEMORY_ENCRYPT_OP

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.3,
+  "coverage_score": 91.2,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -93,6 +93,9 @@ ioctl_ior_nr!(KVM_GET_PIT2, KVMIO, 0x9f, kvm_pit_state2);
 /* Available with KVM_CAP_PIT_STATE2 */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iow_nr!(KVM_SET_PIT2, KVMIO, 0xa0, kvm_pit_state2);
+/* KVM_MEMORY_ENCRYPT_OP. Takes opaque platform dependent type: i.e. TDX or SEV */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_iowr_nr!(KVM_MEMORY_ENCRYPT_OP, KVMIO, 0xba, std::os::raw::c_ulong);
 
 // Ioctls for VCPU fds.
 


### PR DESCRIPTION
This ioctl is used for handling platform encrypted VMs. e.g. for AMD SEV
or for Intel TDX. As it is platform dependent the input parameter is an
opaque platform dependent type.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>