### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# v0.7.0
+
+## Added
+- Support for the system API that returns the maximum allowed vCPU ID
+  (`KVM_CAP_MAX_VCPU_ID`).
+- Support for `KVM_MEMORY_ENCRYPT_OP`.
+
+## Fixed
+- [[#119](https://github.com/rust-vmm/kvm-ioctls/issues/119)]: Disallow invalid
+  number of cpuid entries to be passed to `get_supported_cpuid` and
+  `get_emulated_cpuid`.
+
+## Changed
+- [[#123](https://github.com/rust-vmm/kvm-ioctls/issues/123)]: Updated
+  `create_vcpu` to use `u64` as the parameter for the number of vCPUs.
+
 # v0.6.0
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0 OR MIT"
 [dependencies]
 libc = ">=0.2.39"
 kvm-bindings = { version = ">=0.2.0", features = ["fam-wrappers"] }
-vmm-sys-util = ">=0.2.1"
+vmm-sys-util = ">=0.8.0"
 
 [dev-dependencies]
 byteorder = ">=1.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvm-ioctls"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Amazon Firecracker Team <firecracker-maintainers@amazon.com>"]
 description = "Safe wrappers over KVM ioctls"
 repository = "https://github.com/rust-vmm/kvm-ioctls"


### PR DESCRIPTION
- Update the change log & the packet version.
- Require a vmm-sys-util version > v0.8.0