### PR TITLE
Release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.6.1
+
+## Changed
+
+- Enforced the `vmm-sys-util` dependency to v0.7.0.
+
 # v0.6.0
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 libc = ">=0.2.39"
-kvm-bindings = { version = ">=0.2.0", features = ["fam-wrappers"] }
-vmm-sys-util = ">=0.2.1"
+kvm-bindings = { version = "=0.3.1", features = ["fam-wrappers"] }
+vmm-sys-util = "=0.7.0"
 
 [dev-dependencies]
 byteorder = ">=1.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvm-ioctls"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Amazon Firecracker Team <firecracker-maintainers@amazon.com>"]
 description = "Safe wrappers over KVM ioctls"
 repository = "https://github.com/rust-vmm/kvm-ioctls"


### PR DESCRIPTION
This release enforces the `vmm-sys-util` dependency to `=v0.7.0`.

#141 