### PR TITLE
Expose supplying a type when creating the VM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 libc = ">=0.2.39"
-kvm-bindings = { version = ">=0.2.0", features = ["fam-wrappers"] }
+kvm-bindings = { version = "=0.3.0", features = ["fam-wrappers"] }
 vmm-sys-util = ">=0.8.0"
 
 [dev-dependencies]


### PR DESCRIPTION
The KVM_CREATE_VM ioctl can take a parameter that is a platform and
architecture specific VM type. This can be used for SEV or TDX VMs on
x86_64 platforms of for conveying the IPA size on aarch64 platforms.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>