### PR TITLE
Add KVM_SET_TSC_KHZ and KVM_GET_TSC_KHZ wrappers.

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.2,
+  "coverage_score": 91.4,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -197,6 +197,13 @@ ioctl_iow_nr!(KVM_SET_XCRS, KVMIO, 0xa7, kvm_xcrs);
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_io_nr!(KVM_KVMCLOCK_CTRL, KVMIO, 0xad);
 
+/* Available with KVM_CAP_TSC_CONTROL */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_io_nr!(KVM_SET_TSC_KHZ, KVMIO, 0xa2);
+/* Available with KVM_CAP_GET_TSC_KHZ */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_io_nr!(KVM_GET_TSC_KHZ, KVMIO, 0xa3);
+
 /* Available with KVM_CAP_ENABLE_CAP */
 #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
 ioctl_iow_nr!(KVM_ENABLE_CAP, KVMIO, 0xa3, kvm_enable_cap);


### PR DESCRIPTION
Add wrappers needed to enable TSC scaling for CPUs that support it.

Implemented two vCPU wrappers:
- get_tsc_khz() for KVM_GET_TSC_KHZ - depends on KVM cap KVM_CAP_GET_TSC_KHZ
- set_tsc_khz() for KVM_SET_TSC_KHZ - depends on KVM cap KVM_CAP_TSC_CONTROL