### PR TITLE
Minor enhancement and bugfixes

### DIFF
--- a/src/cap.rs
+++ b/src/cap.rs
@@ -139,6 +139,8 @@ pub enum Cap {
     S390UserSigp = KVM_CAP_S390_USER_SIGP,
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     SplitIrqchip = KVM_CAP_SPLIT_IRQCHIP,
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    DisableExits = KVM_CAP_X86_DISABLE_EXITS,
     ImmediateExit = KVM_CAP_IMMEDIATE_EXIT,
     ArmVmIPASize = KVM_CAP_ARM_VM_IPA_SIZE,
     MsiDevid = KVM_CAP_MSI_DEVID,

--- a/src/ioctls/system.rs
+++ b/src/ioctls/system.rs
@@ -213,9 +213,12 @@ impl Kvm {
     /// assert!(kvm.get_max_vcpus() > 0);
     /// ```
     pub fn get_max_vcpus(&self) -> usize {
-        match self.check_extension_int(Cap::MaxVcpus) {
-            0 => self.get_nr_vcpus(),
-            x => x as usize,
+        let v = self.check_extension_int(Cap::MaxVcpus);
+
+        if v <= 0 {
+            self.get_nr_vcpus()
+        } else {
+            v as usize
         }
     }
 
@@ -233,9 +236,12 @@ impl Kvm {
     /// assert!(kvm.get_max_vcpu_id() > 0);
     /// ```
     pub fn get_max_vcpu_id(&self) -> usize {
-        match self.check_extension_int(Cap::MaxVcpuId) {
-            0 => self.get_max_vcpus(),
-            x => x as usize,
+        let v = self.check_extension_int(Cap::MaxVcpuId);
+
+        if v <= 0 {
+            self.get_max_vcpus()
+        } else {
+            v as usize
         }
     }
 


### PR DESCRIPTION
Enhance the kvm-ioctls with:
1) a new Kvm::get_disable_exits_cap() method
2) a new VcpuFd::vcpu_file() access method
3) export VmFd::new_vmfd()
4) fix bugs in Kvm::get_max_vcpus() and Kvm::get_max_vcpu_id()