### PR TITLE
fix get_cpuid test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ vmm-sys-util = ">=0.8.0"
 
 [dev-dependencies]
 byteorder = ">=1.2.1"
+
+[patch.crates-io]
+kvm-bindings = { git = " https://github.com/andreeaflorescu/kvm-bindings/", branch="add_ord_to_cpuid" }

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -1461,16 +1461,18 @@ mod tests {
         let kvm = Kvm::new().unwrap();
         if kvm.check_extension(Cap::ExtCpuid) {
             let vm = kvm.create_vm().unwrap();
-            let cpuid = kvm.get_supported_cpuid(KVM_MAX_CPUID_ENTRIES).unwrap();
+            let mut cpuid = kvm.get_supported_cpuid(KVM_MAX_CPUID_ENTRIES).unwrap();
+            cpuid.as_mut_slice().sort();
             let ncpuids = cpuid.as_slice().len();
             assert!(ncpuids <= KVM_MAX_CPUID_ENTRIES);
             let nr_vcpus = kvm.get_nr_vcpus();
             for cpu_idx in 0..nr_vcpus {
                 let vcpu = vm.create_vcpu(cpu_idx as u64).unwrap();
                 vcpu.set_cpuid2(&cpuid).unwrap();
-                let retrieved_cpuid = vcpu.get_cpuid2(ncpuids).unwrap();
+                let mut retrieved_cpuid = vcpu.get_cpuid2(ncpuids).unwrap();
+                retrieved_cpuid.as_mut_slice().sort();
                 // Only check the first few leafs as some (e.g. 13) are reserved.
-                assert_eq!(cpuid.as_slice()[..3], retrieved_cpuid.as_slice()[..3]);
+                assert_eq!(cpuid.as_slice()[..13], retrieved_cpuid.as_slice()[0..13]);
             }
         }
     }


### PR DESCRIPTION
Attempt 1 at fixing #152 

<del>For the test_get_cpuid the root cause is clear:
With new kernel versions the CPUID entries are no longer returned in order. To be able to compare cpuid entries we need to first sort them.
This requires changes in kvm-bindings as well as we need first to have the kvm_cpuid_entry2 sortable (i.e. implement Ord and PartialOrd). These are now added to my fork of kvm-bindings.

We should see if we do want to add them in upstream or just modify the test such that sorting is not needed.</del>

LE: It looks like it's not the test that is broken, but `KVM_GET_CPUID2`. We still need to figure out how to make the CI pass.

