### PR TITLE
fix aarch64 clippy warnings

### DIFF
--- a/src/ioctls/device.rs
+++ b/src/ioctls/device.rs
@@ -297,9 +297,11 @@ mod tests {
         // This value should be saved in the address provided to the ioctl.
         let mut data: u32 = 0;
 
-        let mut gic_attr = kvm_bindings::kvm_device_attr::default();
-        gic_attr.group = KVM_DEV_ARM_VGIC_GRP_NR_IRQS;
-        gic_attr.addr = data as u64;
+        let mut gic_attr = kvm_bindings::kvm_device_attr {
+            group: KVM_DEV_ARM_VGIC_GRP_NR_IRQS,
+            addr: data as u64,
+            ..Default::default()
+        };
 
         // Without properly providing the address to where the
         // value will be stored, the ioctl fails with EFAULT.

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -1780,7 +1780,7 @@ mod tests {
             // Get a mutable slice of `mem_size` from `load_addr`.
             // This is safe because we mapped it before.
             let mut slice = std::slice::from_raw_parts_mut(load_addr, mem_size);
-            slice.write(&code).unwrap();
+            slice.write_all(&code).unwrap();
         }
 
         let vcpu_fd = vm.create_vcpu(0).unwrap();
@@ -1825,10 +1825,10 @@ mod tests {
                     // The code snippet dirties one page at guest_addr + 0x10000.
                     // The code page should not be dirty, as it's not written by the guest.
                     let dirty_pages_bitmap = vm.get_dirty_log(slot, mem_size).unwrap();
-                    let dirty_pages = dirty_pages_bitmap
+                    let dirty_pages: u32 = dirty_pages_bitmap
                         .into_iter()
                         .map(|page| page.count_ones())
-                        .fold(0, |dirty_page_count, i| dirty_page_count + i);
+                        .sum();
                     assert_eq!(dirty_pages, 1);
                 }
                 VcpuExit::SystemEvent(type_, flags) => {

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -1291,15 +1291,14 @@ pub(crate) fn create_gic_device(vm: &VmFd, flags: u32) -> DeviceFd {
         fd: 0,
         flags,
     };
-    let device_fd = match vm.create_device(&mut gic_device) {
+    match vm.create_device(&mut gic_device) {
         Ok(fd) => fd,
         Err(_) => {
             gic_device.type_ = kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2;
             vm.create_device(&mut gic_device)
                 .expect("Cannot create KVM vGIC device")
         }
-    };
-    device_fd
+    }
 }
 
 /// Set supported number of IRQs for vGIC.


### PR DESCRIPTION
The warnings are not showing up in the CI because we are not running
clippy checks on aarch64. This will be fixed in a future commit in
rust-vmm-ci. The PR that enables clippy on aarch64 (among other
changes): https://github.com/rust-vmm/rust-vmm-ci/pull/70.