### PR TITLE
README: Link crates.io badge to crate page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://badge.buildkite.com/9e0e6c88972a3248a0908506d6946624da84e4e18c0870c4d0.svg)](https://buildkite.com/rust-vmm/kvm-ioctls-ci)
-![crates.io](https://img.shields.io/crates/v/kvm-ioctls.svg)
+[![crates.io](https://img.shields.io/crates/v/kvm-ioctls.svg)](https://crates.io/crates/kvm-ioctls)
 
 # kvm-ioctls
 


### PR DESCRIPTION
A tiny tweak to README: crates.io badge will link to https://crates.io/crates/kvm-ioctls