### PR TITLE
Return kvm_debug_exit_arch with VcpuExit::Debug

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.4,
+  "coverage_score": 91.2,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
Fixes #162.