### PR TITLE
Add support for `KVM_MEMORY_ENCRYPT_{OP,REG_REGION,UNREG_REGION}`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+fn main() {
+    // Define a `has_sev` attribute, which is used for conditional
+    // execution of SEV-specific tests and examples.
+    if std::path::Path::new("/dev/sev").exists() {
+        println!("cargo:rustc-cfg=has_sev");
+    }
+}

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.2,
+  "coverage_score": 88.0,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -1324,6 +1324,81 @@ impl VmFd {
         // and we know where it will write it (op.error).
         unsafe { self.encrypt_op(op) }
     }
+
+    /// Register a guest memory region which may contain encrypted data.
+    ///
+    /// It is used in the SEV-enabled guest.
+    ///
+    /// See the documentation for `KVM_MEMORY_ENCRYPT_REG_REGION` in the
+    /// [KVM API doc](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt).
+    ///
+    /// # Arguments
+    ///
+    /// * `memory_region` - Guest physical memory region.
+    ///
+    /// # Example
+    #[cfg_attr(has_sev, doc = "```rust")]
+    #[cfg_attr(not(has_sev), doc = "```rust,no_run")]
+    /// # extern crate kvm_bindings;
+    /// # extern crate kvm_ioctls;
+    /// # extern crate libc;
+    /// # use std::{fs::OpenOptions, ptr::null_mut};
+    /// # use std::os::unix::io::AsRawFd;
+    /// use kvm_bindings::bindings::{kvm_enc_region, kvm_sev_cmd, kvm_sev_launch_start, sev_cmd_id_KVM_SEV_LAUNCH_START};
+    /// # use kvm_ioctls::Kvm;
+    /// use libc;
+    ///
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// let sev = OpenOptions::new()
+    ///     .read(true)
+    ///     .write(true)
+    ///     .open("/dev/sev")
+    ///     .unwrap();
+    ///
+    /// // Initialize the SEV platform context.
+    /// let mut init: kvm_sev_cmd = Default::default();
+    /// assert!(vm.encrypt_op_sev(&mut init).is_ok());
+    ///
+    /// // Create the memory encryption context.
+    /// let start_data: kvm_sev_launch_start = Default::default();
+    /// let mut start = kvm_sev_cmd {
+    ///     id: sev_cmd_id_KVM_SEV_LAUNCH_START,
+    ///     data: &start_data as *const kvm_sev_launch_start as _,
+    ///     sev_fd: sev.as_raw_fd() as _,
+    ///     ..Default::default()
+    /// };
+    /// assert!(vm.encrypt_op_sev(&mut start).is_ok());
+    ///
+    /// let addr = unsafe {
+    ///     libc::mmap(
+    ///         null_mut(),
+    ///         4096,
+    ///         libc::PROT_READ | libc::PROT_WRITE,
+    ///         libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+    ///         -1,
+    ///         0,
+    ///     )
+    /// };
+    /// assert_ne!(addr, libc::MAP_FAILED);
+    ///
+    /// let memory_region = kvm_enc_region {
+    ///     addr: addr as _,
+    ///     size: 4096,
+    /// };
+    /// vm.register_enc_memory_region(&memory_region).unwrap();
+    /// ```
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    pub fn register_enc_memory_region(&self, memory_region: &kvm_enc_region) -> Result<()> {
+        // Safe because we know that our file is a VM fd, we know the kernel will only read the
+        // correct amount of memory from our pointer, and we verify the return result.
+        let ret = unsafe { ioctl_with_ref(self, KVM_MEMORY_ENCRYPT_REG_REGION(), memory_region) };
+        if ret == 0 {
+            Ok(())
+        } else {
+            Err(errno::Error::last())
+        }
+    }
 }
 
 /// Helper function to create a new `VmFd`.

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -96,6 +96,9 @@ ioctl_iow_nr!(KVM_SET_PIT2, KVMIO, 0xa0, kvm_pit_state2);
 /* KVM_MEMORY_ENCRYPT_OP. Takes opaque platform dependent type: i.e. TDX or SEV */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iowr_nr!(KVM_MEMORY_ENCRYPT_OP, KVMIO, 0xba, std::os::raw::c_ulong);
+/* Available on SEV-enabled guests. */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_ior_nr!(KVM_MEMORY_ENCRYPT_REG_REGION, KVMIO, 0xbb, kvm_enc_region);
 
 // Ioctls for VCPU fds.
 

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -99,6 +99,9 @@ ioctl_iowr_nr!(KVM_MEMORY_ENCRYPT_OP, KVMIO, 0xba, std::os::raw::c_ulong);
 /* Available on SEV-enabled guests. */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_ior_nr!(KVM_MEMORY_ENCRYPT_REG_REGION, KVMIO, 0xbb, kvm_enc_region);
+/* Available on SEV-enabled guests. */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_ior_nr!(KVM_MEMORY_ENCRYPT_UNREG_REGION, KVMIO, 0xbc, kvm_enc_region);
 
 // Ioctls for VCPU fds.
 


### PR DESCRIPTION
Add support for 3 `ioctls`:
- [KVM_MEMORY_ENCRYPT_OP](https://github.com/torvalds/linux/blob/5af4055fa8133662831ae2fb6e188e8f6c172688/Documentation/virt/kvm/api.rst#4110-kvm_memory_encrypt_op)
- [KVM_MEMORY_ENCRYPT_REG_REGION](https://github.com/torvalds/linux/blob/5af4055fa8133662831ae2fb6e188e8f6c172688/Documentation/virt/kvm/api.rst#4111-kvm_memory_encrypt_reg_region) (SEV-specific)
- [KVM_MEMORY_ENCRYPT_UNREG_REGION](https://github.com/torvalds/linux/blob/5af4055fa8133662831ae2fb6e188e8f6c172688/Documentation/virt/kvm/api.rst#4112-kvm_memory_encrypt_unreg_region) (SEV-specific)

cc @haraldh