### PR TITLE
derive Debug for DeviceFd

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 88.0,
+  "coverage_score": 87.7,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/ioctls/device.rs
+++ b/src/ioctls/device.rs
@@ -11,6 +11,7 @@ use vmm_sys_util::errno;
 use vmm_sys_util::ioctl::{ioctl_with_mut_ref, ioctl_with_ref};
 
 /// Wrapper over the file descriptor obtained when creating an emulated device in the kernel.
+#[derive(Debug)]
 pub struct DeviceFd {
     fd: File,
 }


### PR DESCRIPTION
Without this derive it is hard to write negative tests because we cannot
do unwrap_err.