### PR TITLE
Add support for KVM_SET_IDENTITY_MAP_ADDR

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 87.7,
+  "coverage_score": 87.9,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -36,6 +36,9 @@ ioctl_iow_nr!(
 /* Available with KVM_CAP_SET_TSS_ADDR */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_io_nr!(KVM_SET_TSS_ADDR, KVMIO, 0x47);
+/* Available with KVM_CAP_SET_IDENTITY_MAP_ADDR */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_iow_nr!(KVM_SET_IDENTITY_MAP_ADDR, KVMIO, 0x48, u64);
 /* Available with KVM_CAP_IRQCHIP */
 #[cfg(any(
     target_arch = "x86",


### PR DESCRIPTION
Adding a missing ioctl to the list of supported ioctls. It is useful
to define the address of a one-page region that is needed on Intel
hardware because of a quirk in the virtualization implementation.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>