### PR TITLE
derive debug for all exported structs & enums

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 87.9,
+  "coverage_score": 85.9,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/ioctls/mod.rs
+++ b/src/ioctls/mod.rs
@@ -30,6 +30,7 @@ pub type Result<T> = std::result::Result<T, errno::Error>;
 ///
 /// The wrapper is needed for sending the pointer to `kvm_run` between
 /// threads as raw pointers do not implement `Send` and `Sync`.
+#[derive(Debug)]
 pub struct KvmRunWrapper {
     kvm_run_ptr: *mut u8,
     // This field is need so we can `munmap` the memory mapped to hold `kvm_run`.

--- a/src/ioctls/system.rs
+++ b/src/ioctls/system.rs
@@ -23,6 +23,7 @@ use vmm_sys_util::ioctl::ioctl_with_mut_ptr;
 use vmm_sys_util::ioctl::{ioctl, ioctl_with_val};
 
 /// Wrapper over KVM system ioctls.
+#[derive(Debug)]
 pub struct Kvm {
     kvm: File,
 }

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -96,6 +96,7 @@ pub enum VcpuExit<'a> {
 }
 
 /// Wrapper over KVM vCPU ioctls.
+#[derive(Debug)]
 pub struct VcpuFd {
     vcpu: File,
     kvm_run_ptr: KvmRunWrapper,

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -28,6 +28,7 @@ use vmm_sys_util::ioctl::{ioctl, ioctl_with_mut_ref, ioctl_with_ref, ioctl_with_
 ///
 /// The `IoEventAddress` is used for specifying the type when registering an event
 /// in [register_ioevent](struct.VmFd.html#method.register_ioevent).
+#[derive(Debug)]
 pub enum IoEventAddress {
     /// Representation of an programmable I/O address.
     Pio(u64),
@@ -41,6 +42,7 @@ pub enum IoEventAddress {
 /// [`register_ioevent`](struct.VmFd.html#method.register_ioevent)
 /// to disable filtering of events based on the datamatch flag. For details check the
 /// [KVM API documentation](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt).
+#[derive(Debug)]
 pub struct NoDatamatch;
 impl From<NoDatamatch> for u64 {
     fn from(_: NoDatamatch) -> u64 {
@@ -49,6 +51,7 @@ impl From<NoDatamatch> for u64 {
 }
 
 /// Wrapper over KVM VM ioctls.
+#[derive(Debug)]
 pub struct VmFd {
     vm: File,
     run_size: usize,


### PR DESCRIPTION
This is helping with debugging in the VMM. Because the exported
structures from here are not deriving Debug, deriving it in the VMM is
cumbersome.
