### PR TITLE
Enable usage of sync_regs

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.0,
+  "coverage_score": 85.4,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,6 +216,10 @@ pub use cap::Cap;
 pub use ioctls::device::DeviceFd;
 pub use ioctls::system::Kvm;
 pub use ioctls::vcpu::{VcpuExit, VcpuFd};
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub use ioctls::vcpu::SyncReg;
+
 pub use ioctls::vm::{IoEventAddress, NoDatamatch, VmFd};
 // The following example is used to verify that our public
 // structures are exported properly.


### PR DESCRIPTION
Enable the use of the `sync_regs` API from KVM to allow bulk getting and setting of general purpose registers, system registers, and vcpu events, reducing the number of ioctls needed.