### PR TITLE
Add KVM_TRANSLATE and translate_gva

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.9,
+  "coverage_score": 86.1,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -127,6 +127,8 @@ ioctl_ior_nr!(KVM_GET_SREGS, KVMIO, 0x83, kvm_sregs);
     target_arch = "powerpc64"
 ))]
 ioctl_iow_nr!(KVM_SET_SREGS, KVMIO, 0x84, kvm_sregs);
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_iowr_nr!(KVM_TRANSLATE, KVMIO, 0x85, kvm_translation);
 /* Available with KVM_CAP_GET_MSR_FEATURES */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iowr_nr!(KVM_GET_MSR_INDEX_LIST, KVMIO, 0x02, kvm_msr_list);


### PR DESCRIPTION
This PR adds support for KVM_TRANSLATE and function translate_gva,
translates guest virtual address to the physical address by calling
ioctl as described in [1].

This feature is needed to implement GDB support for Cloud Hypervisor[2].

[1] https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt
[2] https://github.com/cloud-hypervisor/cloud-hypervisor/pull/3575