### PR TITLE
Adjust test coverage

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 86.1,
+  "coverage_score": 85.0,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
This PR includes the original one from dependabot #192 
It adjusts test coverage due to updated Rust version.