### PR TITLE
ioctls: Don't panic on unsupported exit reason

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.4,
+  "coverage_score": 85.3,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -93,6 +93,10 @@ pub enum VcpuExit<'a> {
     IoapicEoi(u8 /* vector */),
     /// Corresponds to KVM_EXIT_HYPERV.
     Hyperv,
+    /// Corresponds to an exit reason that is unknown from the current version
+    /// of the kvm-ioctls crate. Let the consumer decide about what to do with
+    /// it.
+    Unsupported(u32),
 }
 
 /// Wrapper over KVM vCPU ioctls.
@@ -1405,7 +1409,7 @@ impl VcpuFd {
                     Ok(VcpuExit::IoapicEoi(eoi.vector))
                 }
                 KVM_EXIT_HYPERV => Ok(VcpuExit::Hyperv),
-                r => panic!("unknown kvm exit reason: {}", r),
+                r => Ok(VcpuExit::Unsupported(r)),
             }
         } else {
             Err(errno::Error::last())


### PR DESCRIPTION
In case the underlying KVM version is more recent than what is known
and supported by the kvm-ioctls crate, and in case KVM reports an
unknown reason for a VM exit, we don't want the vCPU run() to panic.

A more elegant way of handling such situation is by propagating the exit
reason up to the consumer's crate as it might know what to do with it.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>