### PR TITLE
ioctls: vcpu: Expose details from KVM_EXIT_FAIL_ENTRY exit

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.3,
+  "coverage_score": 84.6,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
Signed-off-by: Rob Bradford <robert.bradford@intel.com>
