### PR TITLE
Add `KVM_CAP_GUEST_DEBUG_HW_BPS/WPS`

### DIFF
--- a/src/cap.rs
+++ b/src/cap.rs
@@ -144,4 +144,6 @@ pub enum Cap {
     MsiDevid = KVM_CAP_MSI_DEVID,
     HypervSynic = KVM_CAP_HYPERV_SYNIC,
     HypervSynic2 = KVM_CAP_HYPERV_SYNIC2,
+    DebugHwBps = KVM_CAP_GUEST_DEBUG_HW_BPS,
+    DebugHwWps = KVM_CAP_GUEST_DEBUG_HW_WPS,
 }

--- a/src/ioctls/system.rs
+++ b/src/ioctls/system.rs
@@ -121,7 +121,22 @@ impl Kvm {
     /// Wrapper over `KVM_CHECK_EXTENSION`.
     ///
     /// Returns 0 if the capability is not available and a positive integer otherwise.
-    fn check_extension_int(&self, c: Cap) -> i32 {
+    /// See the documentation for `KVM_CHECK_EXTENSION`.
+    ///
+    /// # Arguments
+    ///
+    /// * `c` - KVM capability to check.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use kvm_ioctls::Kvm;
+    /// use kvm_ioctls::Cap;
+    ///
+    /// let kvm = Kvm::new().unwrap();
+    /// assert!(kvm.check_extension_int(Cap::MaxVcpuId) > 0);
+    /// ```
+    pub fn check_extension_int(&self, c: Cap) -> i32 {
         // Safe because we know that our file is a KVM fd and that the extension is one of the ones
         // defined by kernel.
         unsafe { ioctl_with_val(self, KVM_CHECK_EXTENSION(), c as c_ulong) }

--- a/src/ioctls/system.rs
+++ b/src/ioctls/system.rs
@@ -97,9 +97,25 @@ impl Kvm {
     /// AArch64 specific call to get the host Intermediate Physical Address space limit.
     ///
     /// Returns 0 if the capability is not available and an integer >= 32 otherwise.
-    #[cfg(any(target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     pub fn get_host_ipa_limit(&self) -> i32 {
         self.check_extension_int(Cap::ArmVmIPASize)
+    }
+
+    /// AArch64 specific call to get the number of supported hardware breakpoints.
+    ///
+    /// Returns 0 if the capability is not available and a positive integer otherwise.
+    #[cfg(target_arch = "aarch64")]
+    pub fn get_guest_debug_hw_bps(&self) -> i32 {
+        self.check_extension_int(Cap::DebugHwBps)
+    }
+
+    /// AArch64 specific call to get the number of supported hardware watchpoints.
+    ///
+    /// Returns 0 if the capability is not available and a positive integer otherwise.
+    #[cfg(target_arch = "aarch64")]
+    pub fn get_guest_debug_hw_wps(&self) -> i32 {
+        self.check_extension_int(Cap::DebugHwWps)
     }
 
     /// Wrapper over `KVM_CHECK_EXTENSION`.
@@ -571,7 +587,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn test_get_host_ipa_limit() {
         let kvm = Kvm::new().unwrap();
         let host_ipa_limit = kvm.get_host_ipa_limit();
@@ -582,6 +598,17 @@ mod tests {
             // if unsupported, the return value should be 0.
             assert_eq!(host_ipa_limit, 0);
         }
+    }
+
+    #[test]
+    #[cfg(target_arch = "aarch64")]
+    fn test_guest_debug_hw_capacity() {
+        let kvm = Kvm::new().unwrap();
+        // The number of supported breakpoints and watchpoints may vary on
+        // different platforms.
+        // It could be 0 if no supported, or any positive integer otherwise.
+        assert!(kvm.get_guest_debug_hw_bps() >= 0);
+        assert!(kvm.get_guest_debug_hw_wps() >= 0);
     }
 
     #[test]


### PR DESCRIPTION
### Summary of the PR

The API `KVM_CAP_GUEST_DEBUG_HW_BPS` and `KVM_CAP_GUEST_DEBUG_HW_WPS`
are required to determine the number of supported guest debug registers.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
