### PR TITLE
ioctls: use u128 in get/set_one_reg

### DIFF
--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -796,8 +796,8 @@ impl VmFd {
     ///
     ///     let core_reg_base: u64 = 0x6030_0000_0010_0000;
     ///     let mmio_addr: u64 = guest_addr + mem_size as u64;
-    ///     vcpu_fd.set_one_reg(core_reg_base + 2 * 32, guest_addr); // set PC
-    ///     vcpu_fd.set_one_reg(core_reg_base + 2 * 0, mmio_addr); // set X0
+    ///     vcpu_fd.set_one_reg(core_reg_base + 2 * 32, guest_addr as u128); // set PC
+    ///     vcpu_fd.set_one_reg(core_reg_base + 2 * 0, mmio_addr as u128); // set X0
     /// }
     ///
     /// loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,8 +156,8 @@
 //!
 //!         let core_reg_base: u64 = 0x6030_0000_0010_0000;
 //!         let mmio_addr: u64 = guest_addr + mem_size as u64;
-//!         vcpu_fd.set_one_reg(core_reg_base + 2 * 32, guest_addr); // set PC
-//!         vcpu_fd.set_one_reg(core_reg_base + 2 * 0, mmio_addr); // set X0
+//!         vcpu_fd.set_one_reg(core_reg_base + 2 * 32, guest_addr as u128); // set PC
+//!         vcpu_fd.set_one_reg(core_reg_base + 2 * 0, mmio_addr as u128); // set X0
 //!     }
 //!
 //!     // 6. Run code on the vCPU.


### PR DESCRIPTION
### Summary of the PR

Arm's register size can go up to 128-bit.

This requires less code than https://github.com/rust-vmm/kvm-ioctls/pull/201

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
