### PR TITLE
ioctls: Add open_with_cloexec_at and new_with_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+## Added
+- [[#213](https://github.com/rust-vmm/kvm-ioctls/pull/213)] Add `Kvm::new_with_path()`
+  and `Kvm::open_with_cloexec_at()` to allowing using kvm device file other than
+  `/dev/kvm`.
+
 # v0.12.0
 
 ## Added


### PR DESCRIPTION
### Summary of the PR

These two functions are the same as `open_with_cloexec` and `new` except they allow users to specify the path to the KVM device file.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
