### PR TITLE
feat: add MSR-related system ioctls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Upcoming Release
+
+## Added
+- [[#219](https://github.com/rust-vmm/kvm-ioctls/pull/219)] Support for
+  `KVM_GET_MSR_FEATURE_INDEX_LIST` and `KVM_GET_MSRS` system ioctls.
+
 # v0.13.0
 
 ## Added

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -146,4 +146,5 @@ pub enum Cap {
     HypervSynic2 = KVM_CAP_HYPERV_SYNIC2,
     DebugHwBps = KVM_CAP_GUEST_DEBUG_HW_BPS,
     DebugHwWps = KVM_CAP_GUEST_DEBUG_HW_WPS,
+    GetMsrFeatures = KVM_CAP_GET_MSR_FEATURES,
 }

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -13,6 +13,8 @@ use kvm_bindings::*;
 
 ioctl_io_nr!(KVM_GET_API_VERSION, KVMIO, 0x00);
 ioctl_io_nr!(KVM_CREATE_VM, KVMIO, 0x01);
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_iowr_nr!(KVM_GET_MSR_INDEX_LIST, KVMIO, 0x02, kvm_msr_list);
 ioctl_io_nr!(KVM_CHECK_EXTENSION, KVMIO, 0x03);
 ioctl_io_nr!(KVM_GET_VCPU_MMAP_SIZE, KVMIO, 0x04);
 /* Available with KVM_CAP_EXT_CPUID */
@@ -21,6 +23,9 @@ ioctl_iowr_nr!(KVM_GET_SUPPORTED_CPUID, KVMIO, 0x05, kvm_cpuid2);
 /* Available with KVM_CAP_EXT_EMUL_CPUID */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iowr_nr!(KVM_GET_EMULATED_CPUID, KVMIO, 0x09, kvm_cpuid2);
+/* Available with KVM_CAP_GET_MSR_FEATURES */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_iowr_nr!(KVM_GET_MSR_FEATURE_INDEX_LIST, KVMIO, 0x0a, kvm_msr_list);
 
 // Ioctls for VM fds.
 
@@ -129,9 +134,6 @@ ioctl_ior_nr!(KVM_GET_SREGS, KVMIO, 0x83, kvm_sregs);
 ioctl_iow_nr!(KVM_SET_SREGS, KVMIO, 0x84, kvm_sregs);
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iowr_nr!(KVM_TRANSLATE, KVMIO, 0x85, kvm_translation);
-/* Available with KVM_CAP_GET_MSR_FEATURES */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-ioctl_iowr_nr!(KVM_GET_MSR_INDEX_LIST, KVMIO, 0x02, kvm_msr_list);
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iowr_nr!(KVM_GET_MSRS, KVMIO, 0x88, kvm_msrs);
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]


### PR DESCRIPTION
### Summary of the PR

Adds two system ioctls for MSR: `KVM_GET_MSR_FEATURE_INDEX_LIST` and `KVM_GET_MSRS`.

### Requirements

These ioctls are required to read features that are available for the VM, stored in MSRs.
This is similar to `KVM_GET_SUPPORTED_CPUID`.

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
