### PR TITLE
feat(aarch64): generic get/set_one_reg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
   `KVM_GET_MSR_FEATURE_INDEX_LIST` and `KVM_GET_MSRS` system ioctls.
 - [[#221](https://github.com/rust-vmm/kvm-ioctls/pull/221)] Add
   `Cap::ArmPmuV3`.
+- [[#223](https://github.com/rust-vmm/kvm-ioctls/pull/223)] aarch64:
+  Updated `get/set_one_reg` to support different registers sizes through
+  byte slices.
 
 # v0.13.0
 

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -784,8 +784,8 @@ impl VmFd {
     ///
     ///     let core_reg_base: u64 = 0x6030_0000_0010_0000;
     ///     let mmio_addr: u64 = guest_addr + mem_size as u64;
-    ///     vcpu_fd.set_one_reg(core_reg_base + 2 * 32, guest_addr as u128); // set PC
-    ///     vcpu_fd.set_one_reg(core_reg_base + 2 * 0, mmio_addr as u128); // set X0
+    ///     vcpu_fd.set_one_reg(core_reg_base + 2 * 32, &guest_addr.to_le_bytes()); // set PC
+    ///     vcpu_fd.set_one_reg(core_reg_base + 2 * 0, &mmio_addr.to_le_bytes()); // set X0
     /// }
     ///
     /// loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,8 +156,10 @@
 //!
 //!         let core_reg_base: u64 = 0x6030_0000_0010_0000;
 //!         let mmio_addr: u64 = guest_addr + mem_size as u64;
-//!         vcpu_fd.set_one_reg(core_reg_base + 2 * 32, guest_addr as u128); // set PC
-//!         vcpu_fd.set_one_reg(core_reg_base + 2 * 0, mmio_addr as u128); // set X0
+//!         // set PC
+//!         vcpu_fd.set_one_reg(core_reg_base + 2 * 32, &guest_addr.to_le_bytes());
+//!         // set X0
+//!         vcpu_fd.set_one_reg(core_reg_base + 2 * 0, &mmio_addr.to_le_bytes());
 //!     }
 //!
 //!     // 6. Run code on the vCPU.


### PR DESCRIPTION
### Summary of the PR
Linux kernel defines arm registers up to 2048 bits wide. To support all different sized the PR changes `get/set_one_reg` methods to accept a byte slice that either contains register data or will have register data be written to.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
