### PR TITLE
Add capabilities for pointer authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   of `Cap` enum.
 - [[#228](https://github.com/rust-vmm/kvm-ioctls/pull/228)] arm64: add
 support for vCPU SVE feature.
+- [[#219](https://github.com/rust-vmm/kvm-ioctls/pull/226)] Add `Cap::ArmPtrAuthAddress`
+  and `Cap::ArmPtrAuthGeneric` capabilities.
 
 # v0.14.0
 

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -150,4 +150,8 @@ pub enum Cap {
     GetMsrFeatures = KVM_CAP_GET_MSR_FEATURES,
     #[cfg(target_arch = "aarch64")]
     ArmSve = KVM_CAP_ARM_SVE,
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    ArmPtrAuthAddress = KVM_CAP_ARM_PTRAUTH_ADDRESS,
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    ArmPtrAuthGeneric = KVM_CAP_ARM_PTRAUTH_GENERIC,
 }

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -20,6 +20,7 @@ use kvm_bindings::*;
 // We are allowing docs to be missing here because this enum is a wrapper
 // over auto-generated code.
 #[allow(missing_docs)]
+#[derive(PartialEq, Eq)]
 pub enum Cap {
     Irqchip = KVM_CAP_IRQCHIP,
     Hlt = KVM_CAP_HLT,

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -2785,4 +2785,23 @@ mod tests {
         assert!(vcpu.has_device_attr(&dist_attr).is_ok());
         assert!(vcpu.set_device_attr(&dist_attr).is_ok());
     }
+
+    #[test]
+    #[cfg(target_arch = "aarch64")]
+    fn test_pointer_authentication() {
+        let kvm = Kvm::new().unwrap();
+        let vm = kvm.create_vm().unwrap();
+        let vcpu = vm.create_vcpu(0).unwrap();
+
+        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
+        vm.get_preferred_target(&mut kvi)
+            .expect("Cannot get preferred target");
+        if kvm.check_extension(Cap::ArmPtrAuthAddress) {
+            kvi.features[0] |= 1 << kvm_bindings::KVM_ARM_VCPU_PTRAUTH_ADDRESS;
+        }
+        if kvm.check_extension(Cap::ArmPtrAuthGeneric) {
+            kvi.features[0] |= 1 << kvm_bindings::KVM_ARM_VCPU_PTRAUTH_GENERIC;
+        }
+        assert!(vcpu.vcpu_init(&kvi).is_ok());
+    }
 }


### PR DESCRIPTION
### Summary of the PR

ARMv8.3 introduces Pointer Authentication Code (PAC) as a mechanism to protect processes from attacks like buffer overflows. 

This PR adds the capabilities for pointer authentication in Aarch64, `KVM_CAP_ARM_PTRAUTH_GENERIC` and `KVM_CAP_ARM_PTRAUTH_ADDRESS`. Also, add a unit test for checking the existence of capabilities and try to enable the feature in the vcpu initialization if present.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
