### PR TITLE
arm64: add support for vCPU SVE feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Upcoming Release
 
+# v0.15.0
+
+## Added
+
+- [[#228](https://github.com/rust-vmm/kvm-ioctls/pull/228)] arm64: add
+support for vCPU SVE feature
+
 # v0.14.0
 
 ## Added

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -148,4 +148,6 @@ pub enum Cap {
     DebugHwBps = KVM_CAP_GUEST_DEBUG_HW_BPS,
     DebugHwWps = KVM_CAP_GUEST_DEBUG_HW_WPS,
     GetMsrFeatures = KVM_CAP_GET_MSR_FEATURES,
+    #[cfg(target_arch = "aarch64")]
+    ArmSve = KVM_CAP_ARM_SVE,
 }

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -240,6 +240,10 @@ ioctl_ior_nr!(KVM_ARM_PREFERRED_TARGET, KVMIO, 0xaf, kvm_vcpu_init);
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 ioctl_iowr_nr!(KVM_GET_REG_LIST, KVMIO, 0xb0, kvm_reg_list);
 
+/* Available with KVM_CAP_ARM_SVE */
+#[cfg(target_arch = "aarch64")]
+ioctl_iow_nr!(KVM_ARM_VCPU_FINALIZE, KVMIO, 0xc2, std::os::raw::c_int);
+
 /* Available with KVM_CAP_SET_GUEST_DEBUG */
 ioctl_iow_nr!(KVM_SET_GUEST_DEBUG, KVMIO, 0x9b, kvm_guest_debug);
 


### PR DESCRIPTION
### Summary of the PR

This commit add support for initialization of vCPU SVE feature on aarch64:
1. Add ArmSve in Cap struct.
2. Add KVM_ARM_VCPU_FINALIZE ioctl in VcpuFd struct, which is used to initialize the finalization of SVE feature for now.