### PR TITLE
feat: additional method to query kvm extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Upcoming Release
 
+## Added
+- [[#230](https://github.com/rust-vmm/kvm-ioctls/pull/230)] Added
+  `check_extension_raw` method to use raw integer values instead
+  of `Cap` enum.
+
 # v0.14.0
 
 ## Added


### PR DESCRIPTION
### Summary of the PR

Added method to query kvm extension using raw integer instead of an enum value.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
