### PR TITLE
vcpu: export reg_size as a public method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Added
 
 ## Changed
+- [[#234](https://github.com/rust-vmm/kvm-ioctls/issues/234)] vcpu: export
+reg_size as a public method.
 
 # v0.15.0
 

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -21,7 +21,7 @@ use vmm_sys_util::ioctl::{ioctl_with_mut_ptr, ioctl_with_ptr, ioctl_with_val};
 
 /// Helper method to obtain the size of the register through its id
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-fn reg_size(reg_id: u64) -> usize {
+pub fn reg_size(reg_id: u64) -> usize {
     2_usize.pow(((reg_id & KVM_REG_SIZE_MASK) >> KVM_REG_SIZE_SHIFT) as u32)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,6 +217,8 @@ mod ioctls;
 pub use cap::Cap;
 pub use ioctls::device::DeviceFd;
 pub use ioctls::system::Kvm;
+#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+pub use ioctls::vcpu::reg_size;
 pub use ioctls::vcpu::{VcpuExit, VcpuFd};
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]


### PR DESCRIPTION
For better use of set_one_reg/get_one_reg on arm, it's useful to export the helper method `reg_size` to be used outside of the crate.

fixes #234

### Summary of the PR

Export `reg_size` as a public function.