### PR TITLE
cap: Skip compiling SetGuestDebug for RISC-V at the moment

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,3 +1,5 @@
 [target.aarch64-unknown-linux-musl]
 rustflags = [ "-C", "target-feature=+crt-static", "-C", "link-arg=-lgcc" ]
 
+[target.riscv64gc-unknown-linux-gnu]
+linker = "riscv64-unknown-linux-gnu-gcc"

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -41,6 +41,13 @@ pub enum Cap {
     Iommu = KVM_CAP_IOMMU,
     DestroyMemoryRegionWorks = KVM_CAP_DESTROY_MEMORY_REGION_WORKS,
     UserNmi = KVM_CAP_USER_NMI,
+    #[cfg(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "s390"
+    ))]
     SetGuestDebug = KVM_CAP_SET_GUEST_DEBUG,
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     ReinjectControl = KVM_CAP_REINJECT_CONTROL,


### PR DESCRIPTION
RISC-V currently doesn't support KVM_CAP_SET_GUEST_DEBUG.

### Summary of the PR

Related: #208
With the conditional compilation, compilation using `riscv64gc-unknown-linux-gnu` is successful.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [N/A] All added/changed functionality has a corresponding unit/integration
  test.
- [N/A] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [N/A] Any newly added `unsafe` code is properly documented.
