### PR TITLE
vm: Conditional compilation for test_set_gsi_routing

### DIFF
--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -2137,6 +2137,12 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "arm",
+        target_arch = "aarch64"
+    ))]
     fn test_set_gsi_routing() {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();


### PR DESCRIPTION
### Summary of the PR

set_gsi_routing is guarded with conditional compilation, so guard test_set_gsi_routing the same way.
See https://github.com/rust-vmm/kvm-ioctls/blob/main/src/ioctls/vm.rs#L532

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [N/A] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [N/A] Any newly added `unsafe` code is properly documented.
