### PR TITLE
cap: add KvmCapStealTime capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## Changed
 - [[#234](https://github.com/rust-vmm/kvm-ioctls/issues/234)] vcpu: export
 reg_size as a public method.
+- [[#239](https://github.com/rust-vmm/kvm-ioctls/pull/239)] Add Cap::KvmCapStealTime
+capability.
 
 # v0.15.0
 

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -162,4 +162,6 @@ pub enum Cap {
     ArmPtrAuthAddress = KVM_CAP_ARM_PTRAUTH_ADDRESS,
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     ArmPtrAuthGeneric = KVM_CAP_ARM_PTRAUTH_GENERIC,
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    KvmCapStealTime = KVM_CAP_STEAL_TIME,
 }


### PR DESCRIPTION
This capability is used for kvm steal time feature.

[Docs for KVM_CAP_STEAL_TIME](https://dri.freedesktop.org/docs/drm/virt/kvm/api.html#kvm-cap-steal-time)
