### PR TITLE
Add support for userspace MSR handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ reg_size as a public method.
   trait for `IoEventAddress` and `NoDatamatch`.
 - [[#242](https://github.com/rust-vmm/kvm-ioctls/pull/242)] x86: add support
   for SMI injection via `Vcpu::smi()` (`KVM_SMI` ioctl).
+- [[#241](https://github.com/rust-vmm/kvm-ioctls/pull/241)] Add support for
+  userspace MSR handling.
 
 # v0.15.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 libc = "0.2.39"
 kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
 vmm-sys-util = "0.11.0"
+bitflags = "2.4.1"
 
 [dev-dependencies]
 byteorder = "1.2.1"

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 88.89,
+  "coverage_score": 87.40,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -164,4 +164,6 @@ pub enum Cap {
     ArmPtrAuthAddress = KVM_CAP_ARM_PTRAUTH_ADDRESS,
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     ArmPtrAuthGeneric = KVM_CAP_ARM_PTRAUTH_GENERIC,
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    X86UserSpaceMsr = KVM_CAP_X86_USER_SPACE_MSR,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,7 @@ pub use ioctls::vcpu::reg_size;
 pub use ioctls::vcpu::{VcpuExit, VcpuFd};
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub use ioctls::vcpu::SyncReg;
+pub use ioctls::vcpu::{MsrExitReason, ReadMsrExit, SyncReg, WriteMsrExit};
 
 pub use ioctls::vm::{IoEventAddress, NoDatamatch, VmFd};
 // The following example is used to verify that our public


### PR DESCRIPTION
### Summary of the PR

Add support for userspace MSR handling. This is done by enabling the `KVM_CAP_X86_USER_SPACE_MSR` capability, which enables two new exits, `KVM_EXIT_X86_RDMSR` and `KVM_EXIT_X86_WRMSR`. This allows a VMM to intercept reads and writes to invalid MSRs instead of having KVM automatically inject a `#GP` into the guest.

This PR adds safe wrappers around `KVM_CAP_X86_USER_SPACE_MSR`, `KVM_EXIT_X86_RDMSR` and `KVM_EXIT_X86_WRMSR`, some helper types and 2 relevant tests.

### Requirements

- [X] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [X] All added/changed functionality has a corresponding unit/integration
  test.
- [X] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [X] Any newly added `unsafe` code is properly documented.
