### PR TITLE
Add support for `KVM_CAP_X86_SMM` / `KVM_SMI`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 ## Changed
 - [[#234](https://github.com/rust-vmm/kvm-ioctls/issues/234)] vcpu: export
 reg_size as a public method.
--[[#243](https://github.com/rust-vmm/kvm-ioctls/pull/243)] derived the `Copy`
- trait for `IoEventAddress` and `NoDatamatch`.
+- [[#243](https://github.com/rust-vmm/kvm-ioctls/pull/243)] derived the `Copy`
+  trait for `IoEventAddress` and `NoDatamatch`.
+- [[#242](https://github.com/rust-vmm/kvm-ioctls/pull/242)] x86: add support
+  for SMI injection via `Vcpu::smi()` (`KVM_SMI` ioctl).
 
 # v0.15.0
 

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -146,6 +146,8 @@ pub enum Cap {
     CheckExtensionVm = KVM_CAP_CHECK_EXTENSION_VM,
     S390UserSigp = KVM_CAP_S390_USER_SIGP,
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    X86Smm = KVM_CAP_X86_SMM,
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     SplitIrqchip = KVM_CAP_SPLIT_IRQCHIP,
     ArmPmuV3 = KVM_CAP_ARM_PMU_V3,
     ImmediateExit = KVM_CAP_IMMEDIATE_EXIT,

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -240,6 +240,10 @@ ioctl_ior_nr!(KVM_ARM_PREFERRED_TARGET, KVMIO, 0xaf, kvm_vcpu_init);
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 ioctl_iowr_nr!(KVM_GET_REG_LIST, KVMIO, 0xb0, kvm_reg_list);
 
+/* Available with KVM_CAP_X86_SMM */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_io_nr!(KVM_SMI, KVMIO, 0xb7);
+
 /* Available with KVM_CAP_ARM_SVE */
 #[cfg(target_arch = "aarch64")]
 ioctl_iow_nr!(KVM_ARM_VCPU_FINALIZE, KVMIO, 0xc2, std::os::raw::c_int);


### PR DESCRIPTION
### Summary of the PR

Allow VMMs to inject System Management Interrupts (SMIs) into the guest via the `KVM_SMI` vcpu ioctl, which is available if the `KVM_CAP_X86_SMM` capability is present.

### Requirements

- [X] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [X] All added/changed functionality has a corresponding unit/integration
  test.
- [X] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [X] Any newly added `unsafe` code is properly documented.
