### PR TITLE
Add support for coalesced MMIO (`KVM_CAP_COALESCED_MMIO` /  `KVM_CAP_COALESCED_PIO`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ reg_size as a public method.
   userspace MSR handling.
 - [[#246](https://github.com/rust-vmm/kvm-ioctls/pull/246)] Add support for
   userspace NMI injection (`KVM_NMI` ioctl).
+- [[#244](https://github.com/rust-vmm/kvm-ioctls/pull/244)] add support for
+  coalesced MMIO (`KVM_CAP_COALESCED_MMIO` / `KVM_CAP_COALESCED_PIO`)
 
 # v0.15.0
 

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -158,6 +158,7 @@ pub enum Cap {
     DebugHwBps = KVM_CAP_GUEST_DEBUG_HW_BPS,
     DebugHwWps = KVM_CAP_GUEST_DEBUG_HW_WPS,
     GetMsrFeatures = KVM_CAP_GET_MSR_FEATURES,
+    CoalescedPio = KVM_CAP_COALESCED_PIO,
     #[cfg(target_arch = "aarch64")]
     ArmSve = KVM_CAP_ARM_SVE,
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]

--- a/src/ioctls/mod.rs
+++ b/src/ioctls/mod.rs
@@ -5,10 +5,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+use std::mem::size_of;
 use std::os::unix::io::AsRawFd;
 use std::ptr::null_mut;
 
-use kvm_bindings::kvm_run;
+use kvm_bindings::{
+    kvm_coalesced_mmio, kvm_coalesced_mmio_ring, kvm_run, KVM_COALESCED_MMIO_PAGE_OFFSET,
+};
 use vmm_sys_util::errno;
 
 /// Wrappers over KVM device ioctls.
@@ -25,6 +28,100 @@ pub mod vm;
 /// This typedef is generally used to avoid writing out errno::Error directly and
 /// is otherwise a direct mapping to Result.
 pub type Result<T> = std::result::Result<T, errno::Error>;
+
+/// A wrapper around the coalesced MMIO ring page.
+#[derive(Debug)]
+pub(crate) struct KvmCoalescedIoRing {
+    addr: *mut kvm_coalesced_mmio_ring,
+    page_size: usize,
+}
+
+impl KvmCoalescedIoRing {
+    /// Maps the coalesced MMIO ring from the vCPU file descriptor.
+    pub(crate) fn mmap_from_fd<F: AsRawFd>(fd: &F) -> Result<Self> {
+        // SAFETY: We trust the sysconf libc function and we're calling it
+        // with a correct parameter.
+        let page_size = match unsafe { libc::sysconf(libc::_SC_PAGESIZE) } {
+            -1 => return Err(errno::Error::last()),
+            ps => ps as usize,
+        };
+
+        let offset = KVM_COALESCED_MMIO_PAGE_OFFSET * page_size as u32;
+        // SAFETY: KVM guarantees that there is a page at offset
+        // KVM_COALESCED_MMIO_PAGE_OFFSET * PAGE_SIZE if the appropriate
+        // capability is available. If it is not, the call will simply
+        // fail.
+        let addr = unsafe {
+            libc::mmap(
+                null_mut(),
+                page_size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_SHARED,
+                fd.as_raw_fd(),
+                offset.into(),
+            )
+        };
+        if addr == libc::MAP_FAILED {
+            return Err(errno::Error::last());
+        }
+        Ok(Self {
+            addr: addr.cast(),
+            page_size,
+        })
+    }
+
+    /// Compute the size of the MMIO ring.
+    /// Taken from [include/uapi/linux/kvm.h](https://elixir.bootlin.com/linux/v6.6/source/include/uapi/linux/kvm.h#L562)
+    const fn ring_max(&self) -> usize {
+        (self.page_size - size_of::<kvm_coalesced_mmio_ring>()) / size_of::<kvm_coalesced_mmio>()
+    }
+
+    /// Gets a mutable reference to the ring
+    fn ring_mut(&mut self) -> &mut kvm_coalesced_mmio_ring {
+        // SAFETY: We have a `&mut self` and the pointer is private, so this
+        // access is exclusive.
+        unsafe { &mut *self.addr }
+    }
+
+    /// Reads a single entry from the MMIO ring.
+    ///
+    /// # Returns
+    ///
+    /// An entry from the MMIO ring buffer, or [`None`] if the ring is empty.
+    pub(crate) fn read_entry(&mut self) -> Option<kvm_coalesced_mmio> {
+        let ring_max = self.ring_max();
+
+        let ring = self.ring_mut();
+        if ring.first == ring.last {
+            return None;
+        }
+
+        let entries = ring.coalesced_mmio.as_ptr();
+        // SAFETY: `ring.first` is an `u32` coming from mapped memory filled
+        // by the kernel, so we trust it. `entries` is a pointer coming from
+        // mmap(), so pointer arithmetic cannot overflow. We have a `&mut self`,
+        // so nobody else has access to the contents of the pointer.
+        let elem = unsafe { entries.add(ring.first as usize).read() };
+        ring.first = (ring.first + 1) % ring_max as u32;
+
+        Some(elem)
+    }
+}
+
+impl Drop for KvmCoalescedIoRing {
+    fn drop(&mut self) {
+        // SAFETY: This is safe because we mmap the page ourselves, and nobody
+        // else is holding a reference to it.
+        unsafe {
+            libc::munmap(self.addr.cast(), self.page_size);
+        }
+    }
+}
+
+// SAFETY: See safety comments about [`KvmRunWrapper`].
+unsafe impl Send for KvmCoalescedIoRing {}
+// SAFETY: See safety comments about [`KvmRunWrapper`].
+unsafe impl Sync for KvmCoalescedIoRing {}
 
 /// Safe wrapper over the `kvm_run` struct.
 ///

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -61,6 +61,20 @@ ioctl_io_nr!(KVM_CREATE_IRQCHIP, KVMIO, 0x60);
     target_arch = "aarch64"
 ))]
 ioctl_iow_nr!(KVM_IRQ_LINE, KVMIO, 0x61, kvm_irq_level);
+/* Available with KVM_CAP_COALESCED_MMIO / KVM_CAP_COALESCED_PIO */
+ioctl_iow_nr!(
+    KVM_REGISTER_COALESCED_MMIO,
+    KVMIO,
+    0x67,
+    kvm_coalesced_mmio_zone
+);
+/* Available with KVM_CAP_COALESCED_MMIO / KVM_CAP_COALESCED_PIO */
+ioctl_iow_nr!(
+    KVM_UNREGISTER_COALESCED_MMIO,
+    KVMIO,
+    0x68,
+    kvm_coalesced_mmio_zone
+);
 /* Available with KVM_CAP_IRQ_ROUTING */
 #[cfg(any(
     target_arch = "x86",


### PR DESCRIPTION
### Summary of the PR

Add support for coalesced MMIO. This performance feature allows guest writes to port and memory space to not trigger VM exits. Instead, the kernel will write an entry into a shared ring buffer for each access, which userspace must consume. The ring buffer is mapped at a certain offset in the vcpu's file descriptor.

In order to enable this capability, introduce the `KvmCoalescedIoRing` struct, which will act as a safe wrapper around the raw mapping of the ring buffer. Since users may not want to use coalesced MMIO, or it might not be available, store it as an `Option` in the `VcpuFd` struct.

Add two tests as well for the newly added code.

The public API consists of:
* A couple of capabilities:
    - `Cap::CoalescedMmio` (`KVM_CAP_COALESCED_MMIO`)
    - `Cap::CoalescedPio` (`KVM_CAP_COALESCED_PIO`).
* Methods to register and unregister addresses that will use this feature:
    - `VmFd::register_coalesced_mmio()` (`KVM_REGISTER_COALESCED_MMIO` ioctl).
    - `VmFd::unregister_coalesced_mmio()` (`KVM_UNREGISTER_COALESCED_MMIO` ioctl).
* A shared ring buffer (mapped with `VcpuFd::map_coalesced_mmio_ring()`).
* A safe method to read from the ring (`VcpuFd::read_coalesced_mmio()`).

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [X] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [X] All added/changed functionality has a corresponding unit/integration
  test.
- [X] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [X] Any newly added `unsafe` code is properly documented.
