### PR TITLE
Add support for userspace NMI injection (`KVM_NMI` / `KVM_CAP_USER_NMI`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ reg_size as a public method.
   for SMI injection via `Vcpu::smi()` (`KVM_SMI` ioctl).
 - [[#241](https://github.com/rust-vmm/kvm-ioctls/pull/241)] Add support for
   userspace MSR handling.
+- [[#246](https://github.com/rust-vmm/kvm-ioctls/pull/246)] Add support for
+  userspace NMI injection (`KVM_NMI` ioctl).
 
 # v0.15.0
 

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 87.40,
+  "coverage_score": 86.74,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -1823,6 +1823,32 @@ impl VcpuFd {
             _ => Err(errno::Error::last()),
         }
     }
+
+    /// Queues an NMI on the thread's vcpu. Only usable if `KVM_CAP_USER_NMI`
+    /// is available.
+    ///
+    /// See the documentation for `KVM_NMI`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use kvm_ioctls::{Kvm, Cap};
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// let vcpu = vm.create_vcpu(0).unwrap();
+    /// if kvm.check_extension(Cap::UserNmi) {
+    ///     vcpu.nmi().unwrap();
+    /// }
+    /// ```
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    pub fn nmi(&self) -> Result<()> {
+        // SAFETY: Safe because we call this with a Vcpu fd and we trust the kernel.
+        let ret = unsafe { ioctl(self, KVM_NMI()) };
+        match ret {
+            0 => Ok(()),
+            _ => Err(errno::Error::last()),
+        }
+    }
 }
 
 /// Helper function to create a new `VcpuFd`.

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -172,6 +172,9 @@ ioctl_ior_nr!(KVM_GET_MP_STATE, KVMIO, 0x98, kvm_mp_state);
     target_arch = "s390"
 ))]
 ioctl_iow_nr!(KVM_SET_MP_STATE, KVMIO, 0x99, kvm_mp_state);
+/* Available with KVM_CAP_USER_NMI */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_io_nr!(KVM_NMI, KVMIO, 0x9a);
 /* Available with KVM_CAP_VCPU_EVENTS */
 #[cfg(any(
     target_arch = "x86",


### PR DESCRIPTION
### Summary of the PR

Add support for the `KVM_NMI` ioctl, which allows a VMM to inject a non maskable interrupt into the guest.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [X] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [X] All added/changed functionality has a corresponding unit/integration
  test.
- [X] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [X] Any newly added `unsafe` code is properly documented.
