### PR TITLE
Update vmm-sys-util to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Changed
 - [[#234](https://github.com/rust-vmm/kvm-ioctls/issues/234)] vcpu: export
-reg_size as a public method.
+  reg\_size as a public method.
 - [[#243](https://github.com/rust-vmm/kvm-ioctls/pull/243)] derived the `Copy`
   trait for `IoEventAddress` and `NoDatamatch`.
 - [[#242](https://github.com/rust-vmm/kvm-ioctls/pull/242)] x86: add support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 [dependencies]
 libc = "0.2.39"
 kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
-vmm-sys-util = "0.11.0"
+vmm-sys-util = "0.12.0"
 bitflags = "2.4.1"
 
 [dev-dependencies]


### PR DESCRIPTION
The update brings a fix for a security vulnerability behind feature-gated code not used by kvm-ioctls (the `with-serde` feature), see GHSA-875g-mfp6-g7f9

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
