### PR TITLE
ioctls/vm: Change kvm_create_device to immutable reference

### DIFF
--- a/src/ioctls/device.rs
+++ b/src/ioctls/device.rs
@@ -59,7 +59,7 @@ impl DeviceFd {
     /// };
     ///
     /// let device_fd = vm
-    ///     .create_device(&mut device)
+    ///     .create_device(&device)
     ///     .expect("Cannot create KVM device");
     ///
     /// let dist_attr = kvm_bindings::kvm_device_attr {
@@ -126,11 +126,11 @@ impl DeviceFd {
     ///         fd: 0,
     ///         flags: 0,
     ///     };
-    ///     let device_fd = match vm.create_device(&mut gic_device) {
+    ///     let device_fd = match vm.create_device(&gic_device) {
     ///         Ok(fd) => fd,
     ///         Err(_) => {
     ///             gic_device.type_ = kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2;
-    ///             vm.create_device(&mut gic_device)
+    ///             vm.create_device(&gic_device)
     ///                 .expect("Cannot create KVM vGIC device")
     ///         }
     ///     };

--- a/src/ioctls/device.rs
+++ b/src/ioctls/device.rs
@@ -208,12 +208,12 @@ mod tests {
             flags: KVM_CREATE_DEVICE_TEST,
         };
         // This fails on x86_64 because there is no VGIC there.
-        assert!(vm.create_device(&mut gic_device).is_err());
+        assert!(vm.create_device(&gic_device).is_err());
 
         gic_device.type_ = kvm_device_type_KVM_DEV_TYPE_VFIO;
 
         let device_fd = vm
-            .create_device(&mut gic_device)
+            .create_device(&gic_device)
             .expect("Cannot create KVM device");
 
         // Following lines to re-construct device_fd are used to test
@@ -258,7 +258,7 @@ mod tests {
         };
         // This fails on aarch64 as it does not use MPIC (MultiProcessor Interrupt Controller),
         // it uses the VGIC.
-        assert!(vm.create_device(&mut gic_device).is_err());
+        assert!(vm.create_device(&gic_device).is_err());
 
         let device_fd = create_gic_device(&vm, 0);
 

--- a/src/ioctls/device.rs
+++ b/src/ioctls/device.rs
@@ -251,7 +251,7 @@ mod tests {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
 
-        let mut gic_device = kvm_bindings::kvm_create_device {
+        let gic_device = kvm_bindings::kvm_create_device {
             type_: kvm_device_type_KVM_DEV_TYPE_FSL_MPIC_20,
             fd: 0,
             flags: KVM_CREATE_DEVICE_TEST,

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -1188,7 +1188,7 @@ impl VmFd {
     ///     }
     /// });
     /// ```
-    pub fn create_device(&self, device: &mut kvm_create_device) -> Result<DeviceFd> {
+    pub fn create_device(&self, device: &kvm_create_device) -> Result<DeviceFd> {
         // SAFETY: Safe because we are calling this with the VM fd and we trust the kernel.
         let ret = unsafe { ioctl_with_ref(self, KVM_CREATE_DEVICE(), device) };
         if ret == 0 {
@@ -1655,11 +1655,11 @@ pub(crate) fn create_gic_device(vm: &VmFd, flags: u32) -> DeviceFd {
         fd: 0,
         flags,
     };
-    match vm.create_device(&mut gic_device) {
+    match vm.create_device(&gic_device) {
         Ok(fd) => fd,
         Err(_) => {
             gic_device.type_ = kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2;
-            vm.create_device(&mut gic_device)
+            vm.create_device(&gic_device)
                 .expect("Cannot create KVM vGIC device")
         }
     }
@@ -1794,7 +1794,7 @@ mod tests {
             flags: KVM_CREATE_DEVICE_TEST,
         };
 
-        let vgic_v2_supported = vm.create_device(&mut gic_device).is_ok();
+        let vgic_v2_supported = vm.create_device(&gic_device).is_ok();
         assert_eq!(vm.create_irq_chip().is_ok(), vgic_v2_supported);
     }
 

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -192,7 +192,7 @@ impl VmFd {
     ///         fd: 0,
     ///         flags: KVM_CREATE_DEVICE_TEST,
     ///     };
-    ///     if vm.create_device(&mut gic_device).is_ok() {
+    ///     if vm.create_device(&gic_device).is_ok() {
     ///         vm.create_irq_chip().unwrap();
     ///     }
     /// }
@@ -1177,13 +1177,13 @@ impl VmFd {
     /// };
     /// // On ARM, creating VGICv3 may fail due to hardware dependency.
     /// // Retry to create VGICv2 in that case.
-    /// let device_fd = vm.create_device(&mut device).unwrap_or_else(|_| {
+    /// let device_fd = vm.create_device(&device).unwrap_or_else(|_| {
     ///     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     ///     panic!("Cannot create VFIO device.");
     ///     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     ///     {
     ///         device.type_ = kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2;
-    ///         vm.create_device(&mut device)
+    ///         vm.create_device(&device)
     ///             .expect("Cannot create vGIC device")
     ///     }
     /// });

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -1788,7 +1788,7 @@ mod tests {
 
         // On ARM/arm64, a GICv2 is created. It's better to check ahead whether GICv2
         // can be emulated or not.
-        let mut gic_device = kvm_bindings::kvm_create_device {
+        let gic_device = kvm_bindings::kvm_create_device {
             type_: kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2,
             fd: 0,
             flags: KVM_CREATE_DEVICE_TEST,


### PR DESCRIPTION
### Summary of the PR

The `device` argument to `VmFd.create_device()` is not modified. With this, the argument does not need to be a mutable reference. This PR changes the `device` argument to an immutable reference and updates the tests + docs to reflect this change.

Although this is public facing, I wasn't sure if this required an entry in CHANGELOG.md. If this is approved and someone feels that it should be an entry, please let me know.