### PR TITLE
Fix soundness issues via `KvmRunWrapper::as_mut_ref()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Changed
 
+- [[#255](https://github.com/rust-vmm/kvm-ioctls/issues/255)]: Fixed a
+  soundness issue when accessing the `kvm_run` struct. `VcpuFd::run()` and
+  `VcpuFd::set_kvm_immediate_exit()` now take `&mut self` as a consequence.
+
 # v0.16.0
 
 ## Added

--- a/src/ioctls/mod.rs
+++ b/src/ioctls/mod.rs
@@ -183,6 +183,14 @@ impl KvmRunWrapper {
     }
 }
 
+impl AsRef<kvm_run> for KvmRunWrapper {
+    fn as_ref(&self) -> &kvm_run {
+        // SAFETY: Safe because we know we mapped enough memory to hold the kvm_run struct because
+        // the kernel told us how large it was.
+        unsafe { &*(self.kvm_run_ptr as *const kvm_run) }
+    }
+}
+
 impl Drop for KvmRunWrapper {
     fn drop(&mut self) {
         // SAFETY: This is safe because we mmap the area at kvm_run_ptr ourselves,

--- a/src/ioctls/mod.rs
+++ b/src/ioctls/mod.rs
@@ -172,8 +172,7 @@ impl KvmRunWrapper {
     }
 
     /// Returns a mutable reference to `kvm_run`.
-    #[allow(clippy::mut_from_ref)]
-    pub fn as_mut_ref(&self) -> &mut kvm_run {
+    pub fn as_mut_ref(&mut self) -> &mut kvm_run {
         #[allow(clippy::cast_ptr_alignment)]
         // SAFETY: Safe because we know we mapped enough memory to hold the kvm_run struct because
         // the kernel told us how large it was.

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -1404,7 +1404,7 @@ impl VcpuFd {
     ///         slice.write(&x86_code).unwrap();
     ///     }
     ///
-    ///     let vcpu_fd = vm.create_vcpu(0).unwrap();
+    ///     let mut vcpu_fd = vm.create_vcpu(0).unwrap();
     ///
     ///     let mut vcpu_sregs = vcpu_fd.get_sregs().unwrap();
     ///     vcpu_sregs.cs.base = 0;
@@ -1429,7 +1429,7 @@ impl VcpuFd {
     ///     }
     /// }
     /// ```
-    pub fn run(&self) -> Result<VcpuExit> {
+    pub fn run(&mut self) -> Result<VcpuExit> {
         // SAFETY: Safe because we know that our file is a vCPU fd and we verify the return result.
         let ret = unsafe { ioctl(self, KVM_RUN()) };
         if ret == 0 {
@@ -1559,7 +1559,7 @@ impl VcpuFd {
     }
 
     /// Sets the `immediate_exit` flag on the `kvm_run` struct associated with this vCPU to `val`.
-    pub fn set_kvm_immediate_exit(&self, val: u8) {
+    pub fn set_kvm_immediate_exit(&mut self, val: u8) {
         let kvm_run = self.kvm_run_ptr.as_mut_ref();
         kvm_run.immediate_exit = val;
     }
@@ -2294,7 +2294,7 @@ mod tests {
             slice.write_all(&code).unwrap();
         }
 
-        let vcpu_fd = vm.create_vcpu(0).unwrap();
+        let mut vcpu_fd = vm.create_vcpu(0).unwrap();
         let mut kvi = kvm_bindings::kvm_vcpu_init::default();
         vm.get_preferred_target(&mut kvi).unwrap();
         kvi.features[0] |= 1 << KVM_ARM_VCPU_PSCI_0_2;
@@ -2399,7 +2399,7 @@ mod tests {
             slice.write_all(&code).unwrap();
         }
 
-        let vcpu_fd = vm.create_vcpu(0).unwrap();
+        let mut vcpu_fd = vm.create_vcpu(0).unwrap();
 
         let mut vcpu_sregs = vcpu_fd.get_sregs().unwrap();
         assert_ne!(vcpu_sregs.cs.base, 0);
@@ -2494,7 +2494,7 @@ mod tests {
 
         let badf_errno = libc::EBADF;
 
-        let faulty_vcpu_fd = VcpuFd {
+        let mut faulty_vcpu_fd = VcpuFd {
             vcpu: unsafe { File::from_raw_fd(-2) },
             kvm_run_ptr: KvmRunWrapper {
                 kvm_run_ptr: mmap_anonymous(10),
@@ -2847,7 +2847,7 @@ mod tests {
     fn test_set_kvm_immediate_exit() {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
-        let vcpu = vm.create_vcpu(0).unwrap();
+        let mut vcpu = vm.create_vcpu(0).unwrap();
         assert_eq!(vcpu.kvm_run_ptr.as_ref().immediate_exit, 0);
         vcpu.set_kvm_immediate_exit(1);
         assert_eq!(vcpu.kvm_run_ptr.as_ref().immediate_exit, 1);
@@ -3135,7 +3135,7 @@ mod tests {
             slice.write_all(&code).unwrap();
         }
 
-        let vcpu = vm.create_vcpu(0).unwrap();
+        let mut vcpu = vm.create_vcpu(0).unwrap();
 
         // Set up special registers
         let mut vcpu_sregs = vcpu.get_sregs().unwrap();
@@ -3204,7 +3204,7 @@ mod tests {
             slice.write_all(&code).unwrap();
         }
 
-        let vcpu = vm.create_vcpu(0).unwrap();
+        let mut vcpu = vm.create_vcpu(0).unwrap();
 
         // Set up special registers
         let mut vcpu_sregs = vcpu.get_sregs().unwrap();

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -1766,7 +1766,7 @@ impl VcpuFd {
     /// ```
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn sync_regs(&self) -> kvm_sync_regs {
-        let kvm_run: &mut kvm_run = self.kvm_run_ptr.as_mut_ref();
+        let kvm_run = self.kvm_run_ptr.as_ref();
 
         // SAFETY: Accessing this union field could be out of bounds if the `kvm_run`
         // allocation isn't large enough. The `kvm_run` region is set using
@@ -2848,9 +2848,9 @@ mod tests {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
-        assert_eq!(vcpu.kvm_run_ptr.as_mut_ref().immediate_exit, 0);
+        assert_eq!(vcpu.kvm_run_ptr.as_ref().immediate_exit, 0);
         vcpu.set_kvm_immediate_exit(1);
-        assert_eq!(vcpu.kvm_run_ptr.as_mut_ref().immediate_exit, 1);
+        assert_eq!(vcpu.kvm_run_ptr.as_ref().immediate_exit, 1);
     }
 
     #[test]
@@ -2922,9 +2922,9 @@ mod tests {
         ];
         for reg in &sync_regs {
             vcpu.set_sync_valid_reg(*reg);
-            assert_eq!(vcpu.kvm_run_ptr.as_mut_ref().kvm_valid_regs, *reg as u64);
+            assert_eq!(vcpu.kvm_run_ptr.as_ref().kvm_valid_regs, *reg as u64);
             vcpu.clear_sync_valid_reg(*reg);
-            assert_eq!(vcpu.kvm_run_ptr.as_mut_ref().kvm_valid_regs, 0);
+            assert_eq!(vcpu.kvm_run_ptr.as_ref().kvm_valid_regs, 0);
         }
 
         // Test that multiple valid SyncRegs can be set at the same time
@@ -2932,7 +2932,7 @@ mod tests {
         vcpu.set_sync_valid_reg(SyncReg::SystemRegister);
         vcpu.set_sync_valid_reg(SyncReg::VcpuEvents);
         assert_eq!(
-            vcpu.kvm_run_ptr.as_mut_ref().kvm_valid_regs,
+            vcpu.kvm_run_ptr.as_ref().kvm_valid_regs,
             SyncReg::Register as u64 | SyncReg::SystemRegister as u64 | SyncReg::VcpuEvents as u64
         );
 
@@ -2945,9 +2945,9 @@ mod tests {
 
         for reg in &sync_regs {
             vcpu.set_sync_dirty_reg(*reg);
-            assert_eq!(vcpu.kvm_run_ptr.as_mut_ref().kvm_dirty_regs, *reg as u64);
+            assert_eq!(vcpu.kvm_run_ptr.as_ref().kvm_dirty_regs, *reg as u64);
             vcpu.clear_sync_dirty_reg(*reg);
-            assert_eq!(vcpu.kvm_run_ptr.as_mut_ref().kvm_dirty_regs, 0);
+            assert_eq!(vcpu.kvm_run_ptr.as_ref().kvm_dirty_regs, 0);
         }
 
         // Test that multiple dirty SyncRegs can be set at the same time
@@ -2955,7 +2955,7 @@ mod tests {
         vcpu.set_sync_dirty_reg(SyncReg::SystemRegister);
         vcpu.set_sync_dirty_reg(SyncReg::VcpuEvents);
         assert_eq!(
-            vcpu.kvm_run_ptr.as_mut_ref().kvm_dirty_regs,
+            vcpu.kvm_run_ptr.as_ref().kvm_dirty_regs,
             SyncReg::Register as u64 | SyncReg::SystemRegister as u64 | SyncReg::VcpuEvents as u64
         );
     }

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -756,7 +756,7 @@ impl VmFd {
     ///     slice.write(&asm_code).unwrap();
     /// }
     ///
-    /// let vcpu_fd = vm.create_vcpu(0).unwrap();
+    /// let mut vcpu_fd = vm.create_vcpu(0).unwrap();
     ///
     /// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     /// {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@
 //!     }
 //!
 //!     // 4. Create one vCPU.
-//!     let vcpu_fd = vm.create_vcpu(0).unwrap();
+//!     let mut vcpu_fd = vm.create_vcpu(0).unwrap();
 //!
 //!     // 5. Initialize general purpose and special registers.
 //!     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]


### PR DESCRIPTION
### Summary of the PR

As detailed in #248, and since `KvmRunWrapper` implements `Send` and `Sync`, `as_mut_ref()` can cause undefined behavior, as two threads can acquire a mutable reference to the `kvm_run` struct via an immutable reference to `KvmRunWrapper`.

Fix this by making `KvmRunWrapper::as_mut_ref()` take `&mut self`, which also gets rid of a clippy warning suppression, and update the callers. This results in potentially breaking changes in the public interface, as several `VcpuFd` methods now take `&mut self` as well.

Fixes: #248 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
