### PR TITLE
Use `NonNull` in `KvmRunWrapper` and `KvmCoalescedIoRing`

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 86.74,
+  "coverage_score": 87.32,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/ioctls/mod.rs
+++ b/src/ioctls/mod.rs
@@ -148,7 +148,7 @@ impl KvmRunWrapper {
     /// # Arguments
     /// * `fd` - File descriptor to mmap from.
     /// * `size` - Size of memory region in bytes.
-    pub fn mmap_from_fd(fd: &dyn AsRawFd, size: usize) -> Result<KvmRunWrapper> {
+    pub fn mmap_from_fd<F: AsRawFd>(fd: &F, size: usize) -> Result<KvmRunWrapper> {
         // SAFETY: This is safe because we are creating a mapping in a place not already used by
         // any other area in this process.
         let addr = unsafe {

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -1935,10 +1935,11 @@ mod tests {
     ))]
     use crate::cap::Cap;
     use crate::ioctls::system::Kvm;
+    use std::ptr::NonNull;
 
     // Helper function for memory mapping `size` bytes of anonymous memory.
     // Panics if the mmap fails.
-    fn mmap_anonymous(size: usize) -> *mut u8 {
+    fn mmap_anonymous(size: usize) -> NonNull<u8> {
         use std::ptr::null_mut;
 
         let addr = unsafe {
@@ -1955,7 +1956,7 @@ mod tests {
             panic!("mmap failed.");
         }
 
-        addr as *mut u8
+        NonNull::new(addr).unwrap().cast()
     }
 
     #[test]
@@ -2273,7 +2274,7 @@ mod tests {
         ];
 
         let mem_size = 0x20000;
-        let load_addr = mmap_anonymous(mem_size);
+        let load_addr = mmap_anonymous(mem_size).as_ptr();
         let guest_addr: u64 = 0x10000;
         let slot: u32 = 0;
         let mem_region = kvm_userspace_memory_region {
@@ -2378,7 +2379,7 @@ mod tests {
         let expected_rips: [u64; 3] = [0x1003, 0x1005, 0x1007];
 
         let mem_size = 0x4000;
-        let load_addr = mmap_anonymous(mem_size);
+        let load_addr = mmap_anonymous(mem_size).as_ptr();
         let guest_addr: u64 = 0x1000;
         let slot: u32 = 0;
         let mem_region = kvm_userspace_memory_region {
@@ -2497,7 +2498,7 @@ mod tests {
         let mut faulty_vcpu_fd = VcpuFd {
             vcpu: unsafe { File::from_raw_fd(-2) },
             kvm_run_ptr: KvmRunWrapper {
-                kvm_run_ptr: mmap_anonymous(10),
+                kvm_run_ptr: mmap_anonymous(10).cast(),
                 mmap_size: 10,
             },
             coalesced_mmio_ring: None,
@@ -2538,7 +2539,7 @@ mod tests {
         let faulty_vcpu_fd = VcpuFd {
             vcpu: unsafe { File::from_raw_fd(-2) },
             kvm_run_ptr: KvmRunWrapper {
-                kvm_run_ptr: mmap_anonymous(10),
+                kvm_run_ptr: mmap_anonymous(10).cast(),
                 mmap_size: 10,
             },
             coalesced_mmio_ring: None,
@@ -2658,7 +2659,7 @@ mod tests {
         let faulty_vcpu_fd = VcpuFd {
             vcpu: unsafe { File::from_raw_fd(-2) },
             kvm_run_ptr: KvmRunWrapper {
-                kvm_run_ptr: mmap_anonymous(10),
+                kvm_run_ptr: mmap_anonymous(10).cast(),
                 mmap_size: 10,
             },
             coalesced_mmio_ring: None,
@@ -2976,7 +2977,7 @@ mod tests {
             ];
 
             let mem_size = 0x4000;
-            let load_addr = mmap_anonymous(mem_size);
+            let load_addr = mmap_anonymous(mem_size).as_ptr();
             let guest_addr: u64 = 0x1000;
             let slot: u32 = 0;
             let mem_region = kvm_userspace_memory_region {
@@ -3116,7 +3117,7 @@ mod tests {
         vm.enable_cap(&cap).unwrap();
 
         let mem_size = 0x4000;
-        let load_addr = mmap_anonymous(mem_size);
+        let load_addr = mmap_anonymous(mem_size).as_ptr();
         let guest_addr: u64 = 0x1000;
         let slot: u32 = 0;
         let mem_region = kvm_userspace_memory_region {
@@ -3185,7 +3186,7 @@ mod tests {
         vm.enable_cap(&cap).unwrap();
 
         let mem_size = 0x4000;
-        let load_addr = mmap_anonymous(mem_size);
+        let load_addr = mmap_anonymous(mem_size).as_ptr();
         let guest_addr: u64 = 0x1000;
         let slot: u32 = 0;
         let mem_region = kvm_userspace_memory_region {
@@ -3259,7 +3260,7 @@ mod tests {
 
         // Prepare guest memory
         let mem_size = 0x4000;
-        let load_addr = mmap_anonymous(mem_size);
+        let load_addr = mmap_anonymous(mem_size).as_ptr();
         let guest_addr: u64 = 0x1000;
         let slot = 0;
         let mem_region = kvm_userspace_memory_region {
@@ -3356,7 +3357,7 @@ mod tests {
 
         // Prepare guest memory
         let mem_size = 0x4000;
-        let load_addr = mmap_anonymous(mem_size);
+        let load_addr = mmap_anonymous(mem_size).as_ptr();
         let guest_addr: u64 = 0x1000;
         let slot: u32 = 0;
         let mem_region = kvm_userspace_memory_region {


### PR DESCRIPTION
### Summary of the PR

* The pointers in `KvmRunWrapper` and `KvmCoalescedIoRing` should never be NULL, so store them as such.
* Properly encode the types of these pointers (instead of having a pointer to an `u8`).
* Do not needlessly use dynamic dispatch in `KvmRunWrapper::mmap_from_fd()`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [X] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [X] All added/changed functionality has a corresponding unit/integration
  test.
- `N/A` All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [X] Any newly added `unsafe` code is properly documented.
