### PR TITLE
move encrypt_op{_sev} into system ioctls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - [[#255](https://github.com/rust-vmm/kvm-ioctls/issues/255)]: Fixed a
   soundness issue when accessing the `kvm_run` struct. `VcpuFd::run()` and
   `VcpuFd::set_kvm_immediate_exit()` now take `&mut self` as a consequence.
+- Changed `encrypt_op` and `encrypt_op_sev` to system ioctls to be in line 
+  with the KVM API
 
 # v0.16.0
 


### PR DESCRIPTION
### Summary of the PR

According to the KVM API, `KVM_MEMORY_ENCRYPT_OP` is labeled as a system ioctl. However, it is currently treated as a VM ioctl. There are no functional changes to the code, only the location and function signature. 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
