### PR TITLE
[RFC] Add support for `KVM_GET_XSAVE2` ioctls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- [[#261](https://github.com/rust-vmm/kvm-ioctls/pull/261)]: Add support
+  for `KVM_CAP_XSAVE2` and the `KVM_GET_XSAVE2` ioctl.
+
 ### Changed
 
 ## v0.17.0

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -93,6 +93,8 @@ pub enum Cap {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     Xsave = KVM_CAP_XSAVE,
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    Xsave2 = KVM_CAP_XSAVE2,
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     Xcrs = KVM_CAP_XCRS,
     PpcGetPvinfo = KVM_CAP_PPC_GET_PVINFO,
     PpcIrqLevel = KVM_CAP_PPC_IRQ_LEVEL,

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -214,6 +214,9 @@ ioctl_iow_nr!(KVM_SET_DEBUGREGS, KVMIO, 0xa2, kvm_debugregs);
 /* Available with KVM_CAP_XSAVE */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_ior_nr!(KVM_GET_XSAVE, KVMIO, 0xa4, kvm_xsave);
+/* Available with KVM_CAP_XSAVE2 */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_ior_nr!(KVM_GET_XSAVE2, KVMIO, 0xcf, kvm_xsave);
 /* Available with KVM_CAP_XSAVE */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iow_nr!(KVM_SET_XSAVE, KVMIO, 0xa5, kvm_xsave);


### PR DESCRIPTION
Since Linux 5.17, the `kvm_xsave` struct has a flexible array member (FAM) at the end, which can be retrieved using the `KVM_GET_XSAVE2` ioctl [[1]]. What makes this FAM special is that the length is not stored in the header, but has to be retrieved via
`KVM_CHECK_CAPABILITY(KVM_CAP_XSAVE2)`, which returns the total size of the `kvm_xsave` struct (e.g. the traditional 4096 byte header + the size of the FAM). Thus, to support `KVM_GET_XSAVE2`, we first need to check the capability on the VM fd, construct a FamStructWrapper of the correct size, and then call `KVM_GET_XSAVE2`.

[1]: https://www.kernel.org/doc/html/latest/virt/kvm/api.html#kvm-get-xsave2

I'm marking this as "RFC" because I'm not quite sure how to best deal the combination of "check capability on VM FD" and "do ioctl on vcpu FD". In this patch, I simply add a `VmFd` parameter to `Vcpu::get_xsave2`, but that's kinda ugly. Alternatively, we could store a reference to the VM file descriptor inside each `Vcpu` structure, but that'd be a larger change. What do people think about this?

~~(also, this PR needs https://github.com/rust-vmm/kvm-bindings/pull/104, because Rust apparently only type checks type aliases at use-sites instead of definition-site, meaning I did not notice that I forgot to implement `Default` for `kvm_xsave2` when working on the new kvm-bindings release. That's why the CI is failing here for now)~~

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
