### PR TITLE
Add KVM_SET_USER_MEMORY_REGION2 and KVM_CREATE_GUEST_MEMFD ioctls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2.39"
-kvm-bindings = { version = "0.8.0", features = ["fam-wrappers"] }
+kvm-bindings = { version = "0.9.0", features = ["fam-wrappers"] }
 vmm-sys-util = "0.12.1"
 bitflags = "2.4.1"
 

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -1475,7 +1475,9 @@ impl VcpuFd {
                         nr: hypercall.nr,
                         args: hypercall.args,
                         ret: &mut hypercall.ret,
-                        longmode: hypercall.longmode,
+                        // SAFETY: Safe because the exit_reason (which comes from the kernel) told us
+                        // which union field to use.
+                        longmode: unsafe { hypercall.__bindgen_anon_1.longmode },
                     }))
                 }
                 KVM_EXIT_DEBUG => {

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -50,6 +50,8 @@ ioctl_io_nr!(KVM_SET_TSS_ADDR, KVMIO, 0x47);
 /* Available with KVM_CAP_SET_IDENTITY_MAP_ADDR */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iow_nr!(KVM_SET_IDENTITY_MAP_ADDR, KVMIO, 0x48, u64);
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+ioctl_iowr_nr!(KVM_CREATE_GUEST_MEMFD, KVMIO, 0xd4, kvm_create_guest_memfd);
 /* Available with KVM_CAP_IRQCHIP */
 #[cfg(any(
     target_arch = "x86",

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -276,6 +276,14 @@ ioctl_iow_nr!(KVM_ARM_VCPU_FINALIZE, KVMIO, 0xc2, std::os::raw::c_int);
 /* Available with KVM_CAP_SET_GUEST_DEBUG */
 ioctl_iow_nr!(KVM_SET_GUEST_DEBUG, KVMIO, 0x9b, kvm_guest_debug);
 
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+ioctl_iow_nr!(
+    KVM_SET_MEMORY_ATTRIBUTES,
+    KVMIO,
+    0xd2,
+    kvm_memory_attributes
+);
+
 // Device ioctls.
 
 /* Available with KVM_CAP_DEVICE_CTRL */

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -38,6 +38,12 @@ ioctl_iow_nr!(
     0x46,
     kvm_userspace_memory_region
 );
+ioctl_iow_nr!(
+    KVM_SET_USER_MEMORY_REGION2,
+    KVMIO,
+    0x49,
+    kvm_userspace_memory_region2
+);
 /* Available with KVM_CAP_SET_TSS_ADDR */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_io_nr!(KVM_SET_TSS_ADDR, KVMIO, 0x47);


### PR DESCRIPTION
### Summary of the PR
Add support for KVM_SET_USER_MEMORY_REGION2 and KVM_CREATE_GUEST_MEMFD ioctls and their structures (see #262). This PR requires to update kvm-bidings so I keep it as draft until then. 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
