### PR TITLE
Add test for vcpu_init with an invalid target

### DIFF
--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -2646,6 +2646,23 @@ mod tests {
 
     #[test]
     #[cfg(target_arch = "aarch64")]
+    fn test_faulty_vcpu_target_aarch64() {
+        let kvm = Kvm::new().unwrap();
+        let vm = kvm.create_vm().unwrap();
+        let vcpu = vm.create_vcpu(0).unwrap();
+
+        // KVM defines valid targets as 0 to KVM_ARM_NUM_TARGETS-1, so pick a big raw number
+        // greater than that as target to be invalid
+        let kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init {
+            target: 300,
+            ..Default::default()
+        };
+
+        assert!(vcpu.vcpu_init(&kvi).is_err());
+    }
+
+    #[test]
+    #[cfg(target_arch = "aarch64")]
     fn test_faulty_vcpu_fd_aarch64() {
         use std::os::unix::io::FromRawFd;
 
@@ -2729,7 +2746,6 @@ mod tests {
         let vcpu = vm.create_vcpu(0).unwrap();
 
         let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
-        assert!(vcpu.vcpu_init(&kvi).is_err());
 
         vm.get_preferred_target(&mut kvi)
             .expect("Cannot get preferred target");


### PR DESCRIPTION
### Summary of the PR

To test vcpu_init, replace the zeroed value with the invalid value KVM_ARM_NUM_TARGETS. Put the test in a separate test from the test_get_preferred_target test. This fixes issue #265. 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
