### PR TITLE
expose fields for KVM_EXIT_HYPERCALL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- [[#267](https://github.com/rust-vmm/kvm-ioctls/pull/267)]: Added `HypercallExit` field to `VcpuExit::Hypercall` and added `ExitHypercall` to `Cap`.
+
 ### Changed
 
 ## v0.17.0

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -167,5 +167,6 @@ pub enum Cap {
     ArmPtrAuthGeneric = KVM_CAP_ARM_PTRAUTH_GENERIC,
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     X86UserSpaceMsr = KVM_CAP_X86_USER_SPACE_MSR,
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     ExitHypercall = KVM_CAP_EXIT_HYPERCALL,
 }

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -167,4 +167,5 @@ pub enum Cap {
     ArmPtrAuthGeneric = KVM_CAP_ARM_PTRAUTH_GENERIC,
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     X86UserSpaceMsr = KVM_CAP_X86_USER_SPACE_MSR,
+    ExitHypercall = KVM_CAP_EXIT_HYPERCALL,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,7 @@ pub use ioctls::device::DeviceFd;
 pub use ioctls::system::Kvm;
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 pub use ioctls::vcpu::reg_size;
-pub use ioctls::vcpu::{VcpuExit, VcpuFd};
+pub use ioctls::vcpu::{HypercallExit, VcpuExit, VcpuFd};
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub use ioctls::vcpu::{MsrExitReason, ReadMsrExit, SyncReg, WriteMsrExit};


### PR DESCRIPTION

This is a **breaking change**.

### Summary of the PR

This is needed for userspace to handle the `KVM_HC_MAP_GPA_RANGE` hypercall.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [X] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [X] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [X] Any newly added `unsafe` code is properly documented.
