### PR TITLE
Propagate MemoryFault exit reason in KVM_RUN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - [[#267](https://github.com/rust-vmm/kvm-ioctls/pull/267)]: Added `HypercallExit` field to `VcpuExit::Hypercall` and added `ExitHypercall` to `Cap`.
+- [[#270](https://github.com/rust-vmm/kvm-ioctls/pull/270)]: Added `MemoryFaultInfo` to `Cap` and propagated `MemoryFault` exit reason in `KVM_RUN`.
 
 ### Changed
 

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -169,4 +169,6 @@ pub enum Cap {
     X86UserSpaceMsr = KVM_CAP_X86_USER_SPACE_MSR,
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     ExitHypercall = KVM_CAP_EXIT_HYPERCALL,
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    MemoryFaultInfo = KVM_CAP_MEMORY_FAULT_INFO,
 }


### PR DESCRIPTION
### Summary of the PR

- Add [`KVM_CAP_MEMORY_FAULT_INFO`](https://docs.kernel.org/virt/kvm/api.html#kvm-cap-memory-fault-info) variant to `Cap`
- Propagate `KVM_EXIT_MEMORY_FAULT` exit reason in [`KVM_RUN`](https://docs.kernel.org/virt/kvm/api.html#kvm-run).

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- ~~[ ] All added/changed functionality has a corresponding unit/integration
  test.~~
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- ~~[ ] Any newly added `unsafe` code is properly documented.~~
