### PR TITLE
Fix IO safety runtime errors in tests

### DIFF
--- a/src/ioctls/system.rs
+++ b/src/ioctls/system.rs
@@ -730,6 +730,7 @@ mod tests {
     #![allow(clippy::undocumented_unsafe_blocks)]
     use super::*;
     use libc::{fcntl, FD_CLOEXEC, F_GETFD};
+    use std::os::fd::IntoRawFd;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use vmm_sys_util::fam::FamStruct;
 
@@ -978,5 +979,9 @@ mod tests {
             );
         }
         assert_eq!(faulty_kvm.create_vm().err().unwrap().errno(), badf_errno);
+
+        // Don't drop the File object, or it'll notice the file it's trying to close is
+        // invalid and abort the process.
+        faulty_kvm.kvm.into_raw_fd();
     }
 }

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -2543,7 +2543,7 @@ mod tests {
         target_arch = "aarch64"
     ))]
     fn test_faulty_vcpu_fd() {
-        use std::os::unix::io::FromRawFd;
+        use std::os::unix::io::{FromRawFd, IntoRawFd};
 
         let badf_errno = libc::EBADF;
 
@@ -2579,12 +2579,16 @@ mod tests {
             badf_errno
         );
         assert_eq!(faulty_vcpu_fd.run().unwrap_err().errno(), badf_errno);
+
+        // Don't drop the File object, or it'll notice the file it's trying to close is
+        // invalid and abort the process.
+        faulty_vcpu_fd.vcpu.into_raw_fd();
     }
 
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_faulty_vcpu_fd_x86_64() {
-        use std::os::unix::io::FromRawFd;
+        use std::os::unix::io::{FromRawFd, IntoRawFd};
 
         let badf_errno = libc::EBADF;
 
@@ -2699,6 +2703,10 @@ mod tests {
         assert!(faulty_vcpu_fd.get_tsc_khz().is_err());
         assert!(faulty_vcpu_fd.set_tsc_khz(1000000).is_err());
         assert!(faulty_vcpu_fd.translate_gva(u64::MAX).is_err());
+
+        // Don't drop the File object, or it'll notice the file it's trying to close is
+        // invalid and abort the process.
+        faulty_vcpu_fd.vcpu.into_raw_fd();
     }
 
     #[test]
@@ -2721,7 +2729,7 @@ mod tests {
     #[test]
     #[cfg(target_arch = "aarch64")]
     fn test_faulty_vcpu_fd_aarch64() {
-        use std::os::unix::io::FromRawFd;
+        use std::os::unix::io::{FromRawFd, IntoRawFd};
 
         let badf_errno = libc::EBADF;
 
@@ -2793,6 +2801,10 @@ mod tests {
                 .errno(),
             badf_errno
         );
+
+        // Don't drop the File object, or it'll notice the file it's trying to close is
+        // invalid and abort the process.
+        faulty_vcpu_fd.vcpu.into_raw_fd();
     }
 
     #[test]

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -1949,7 +1949,7 @@ mod tests {
     use crate::Kvm;
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    use std::{fs::OpenOptions, ptr::null_mut};
+    use std::{fs::OpenOptions, os::fd::IntoRawFd, ptr::null_mut};
 
     use libc::EFD_NONBLOCK;
 
@@ -2395,6 +2395,10 @@ mod tests {
             faulty_vm_fd.get_dirty_log(0, 0).unwrap_err().errno(),
             badf_errno
         );
+
+        // Don't drop the File object, or it'll notice the file it's trying to close is
+        // invalid and abort the process.
+        faulty_vm_fd.vm.into_raw_fd();
     }
 
     #[test]


### PR DESCRIPTION
### Summary of the PR

If debug_assertions is enabled, [Rust 1.80.0 and later will abort the process when attempting to close a file descriptor that is already closed][1].  This means that, in tests, where an invalid file descriptor object is deliberately constructed, we have to avoid that object being dropped.  Using `into_raw_fd()` allows the object's memory to be freed (unlike `std::mem::forget()`), without attempting to close the file descriptor.

[1]: https://github.com/rust-lang/rust/commit/cb4940645775f60d74aee2e018d6c516c5aa9ed7

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
