### PR TITLE
Mark DeviceFd::get_device_attr as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Changed
 
+- [[#273](https://github.com/rust-vmm/kvm-ioctls/pull/273)]: `DeviceFd::get_device_attr` is now
+  marked as unsafe.
+
 ## v0.18.0
 
 ### Added


### PR DESCRIPTION
### Summary of the PR

`KVM_GET_DEVICE_ATTR` causes the kernel to write to an arbitrary address.  This is unsafe, as it can allow writing to an address Rust believes to be immutable.

I discovered this because an [optimisation change][1] in Rust 1.80.0 caused a Cloud Hypervisor test to start failing when built in release mode, because it was setting the addr passed to `get_device_attr()` to the address of an immutable variable.

[1]: https://github.com/rust-lang/rust/commit/d2d24e395a1e4fcee62ca17bf4cbddb1f903af97

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
