### PR TITLE
README: stop saying that aarch64 is experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,7 @@ as the code documentation.
 
 ## Supported Platforms
 
-The kvm-ioctls can be used on x86_64 and aarch64. Right now the aarch64 support
-is considered experimental. For a production ready version, please check the
-progress in the corresponding
-[GitHub issue](https://github.com/rust-vmm/kvm-ioctls/issues/8).
+The kvm-ioctls can be used on x86_64 and aarch64.
 
 ## Running the tests
 


### PR DESCRIPTION
### Summary of the PR

The linked issue, and the other one linked from it have been closed for a long time, and this crate is widely used on aarch64.

(Perhaps I'm wrong and there's something else that means kvm-ioctls should still be considered experimental on aarch64, but in that case the README should link somewhere other than a closed issue.)

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
