### PR TITLE
Update kvm-bindings to 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [[#273](https://github.com/rust-vmm/kvm-ioctls/pull/273)]: `DeviceFd::get_device_attr` is now
   marked as unsafe.
+- [[#277](https://github.com/rust-vmm/kvm-ioctls/pull/277)]: Updated kvm-bindings to 0.9.1.
 
 ## v0.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ support for vCPU SVE feature.
   `KVM_GET_MSR_FEATURE_INDEX_LIST` and `KVM_GET_MSRS` system ioctls.
 - [[#221](https://github.com/rust-vmm/kvm-ioctls/pull/221)] Add
   `Cap::ArmPmuV3`.
-  
+
 ### Changed
 
 - [[#223](https://github.com/rust-vmm/kvm-ioctls/pull/223)] aarch64:
@@ -84,10 +84,10 @@ support for vCPU SVE feature.
 
 ### Added
 
-- [[#187](https://github.com/rust-vmm/kvm-ioctls/pull/187)] Support for 
+- [[#187](https://github.com/rust-vmm/kvm-ioctls/pull/187)] Support for
   `KVM_SET_IDENTITY_MAP_ADDR`
 - Derive Debug for all exported structs and enums
-- [[#189](https://github.com/rust-vmm/kvm-ioctls/pull/189)] Expose `KVM_SET_` and 
+- [[#189](https://github.com/rust-vmm/kvm-ioctls/pull/189)] Expose `KVM_SET_` and
   `KVM_HAS_DEVICE_ATTR` for vcpu
 - [[#191](https://github.com/rust-vmm/kvm-ioctls/pull/191)] Add `KVM_TRANSLATE` support and
   the `translate_gva` function that translates guest virtual address to the physical address
@@ -112,7 +112,7 @@ support for vCPU SVE feature.
 - [[#195](https://github.com/rust-vmm/kvm-ioctls/pull/195)] Do not panic on unsupported
   `KVM_EXIT` reason
 - [[#196](https://github.com/rust-vmm/kvm-ioctls/pull/196)] Expose a mutable reference
-  to the `kvm_run` structure to allow proper handling of unsupported exit reasons 
+  to the `kvm_run` structure to allow proper handling of unsupported exit reasons
 - [[#200](https://github.com/rust-vmm/kvm-ioctls/pull/200)] Fix wrong `target_arch` gate
   preventing `set_guest_debug` from being exported on ARM
 - [[#206](https://github.com/rust-vmm/kvm-ioctls/pull/206)] use `u128` in `get/set_on_reg`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2.39"
-kvm-bindings = { version = "0.9.0", features = ["fam-wrappers"] }
+kvm-bindings = { version = "0.9.1", features = ["fam-wrappers"] }
 vmm-sys-util = "0.12.1"
 bitflags = "2.4.1"
 


### PR DESCRIPTION
### Summary of the PR

This PR updated to kvm-bindings v0.9.1 to include a recent bug fixes [1].

[1] https://github.com/rust-vmm/kvm-bindings/pull/113

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
