### PR TITLE
build: Bump kvm-bindings from 0.9.1 to 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2.39"
-kvm-bindings = { version = "0.9.1", features = ["fam-wrappers"] }
+kvm-bindings = { version = "0.10.0", features = ["fam-wrappers"] }
 vmm-sys-util = "0.12.1"
 bitflags = "2.4.1"
 


### PR DESCRIPTION
### Summary of the PR

kvm-bindings 0.10.0 incorporates RISC-V bindings.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
