### PR TITLE
build: Fix unexpected target_arch and attribute warning

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 fn main() {
+    // Add `has_sev` to expected attributes.
+    println!("cargo:rustc-check-cfg=cfg(has_sev)");
     // Define a `has_sev` attribute, which is used for conditional
     // execution of SEV-specific tests and examples.
     if std::path::Path::new("/dev/sev").exists() {

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -46,7 +46,7 @@ pub enum Cap {
         target_arch = "x86_64",
         target_arch = "arm",
         target_arch = "aarch64",
-        target_arch = "s390"
+        target_arch = "s390x"
     ))]
     SetGuestDebug = KVM_CAP_SET_GUEST_DEBUG,
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -796,7 +796,7 @@ impl VcpuFd {
         target_arch = "x86_64",
         target_arch = "arm",
         target_arch = "aarch64",
-        target_arch = "s390"
+        target_arch = "s390x"
     ))]
     pub fn get_mp_state(&self) -> Result<kvm_mp_state> {
         let mut mp_state = Default::default();
@@ -834,7 +834,7 @@ impl VcpuFd {
         target_arch = "x86_64",
         target_arch = "arm",
         target_arch = "aarch64",
-        target_arch = "s390"
+        target_arch = "s390x"
     ))]
     pub fn set_mp_state(&self, mp_state: kvm_mp_state) -> Result<()> {
         // SAFETY: Here we trust the kernel not to read past the end of the kvm_mp_state struct.
@@ -1279,8 +1279,8 @@ impl VcpuFd {
         target_arch = "x86",
         target_arch = "x86_64",
         target_arch = "aarch64",
-        target_arch = "s390",
-        target_arch = "ppc"
+        target_arch = "s390x",
+        target_arch = "powerpc"
     ))]
     pub fn set_guest_debug(&self, debug_struct: &kvm_guest_debug) -> Result<()> {
         // SAFETY: Safe because we allocated the structure and we trust the kernel.
@@ -2234,7 +2234,7 @@ mod tests {
         target_arch = "x86_64",
         target_arch = "arm",
         target_arch = "aarch64",
-        target_arch = "s390"
+        target_arch = "s390x"
     ))]
     #[test]
     fn mpstate_test() {

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -58,7 +58,7 @@ ioctl_iowr_nr!(KVM_CREATE_GUEST_MEMFD, KVMIO, 0xd4, kvm_create_guest_memfd);
     target_arch = "x86_64",
     target_arch = "arm",
     target_arch = "aarch64",
-    target_arch = "s390"
+    target_arch = "s390x"
 ))]
 ioctl_io_nr!(KVM_CREATE_IRQCHIP, KVMIO, 0x60);
 /* Available with KVM_CAP_IRQCHIP */
@@ -97,7 +97,7 @@ ioctl_iow_nr!(KVM_SET_GSI_ROUTING, KVMIO, 0x6a, kvm_irq_routing);
     target_arch = "x86_64",
     target_arch = "arm",
     target_arch = "aarch64",
-    target_arch = "s390"
+    target_arch = "s390x"
 ))]
 ioctl_iow_nr!(KVM_IRQFD, KVMIO, 0x76, kvm_irqfd);
 /* Available with KVM_CAP_PIT2 */
@@ -182,7 +182,7 @@ ioctl_iowr_nr!(KVM_GET_CPUID2, KVMIO, 0x91, kvm_cpuid2);
     target_arch = "x86_64",
     target_arch = "arm",
     target_arch = "aarch64",
-    target_arch = "s390"
+    target_arch = "s390x"
 ))]
 ioctl_ior_nr!(KVM_GET_MP_STATE, KVMIO, 0x98, kvm_mp_state);
 /* Available with KVM_CAP_MP_STATE */
@@ -191,7 +191,7 @@ ioctl_ior_nr!(KVM_GET_MP_STATE, KVMIO, 0x98, kvm_mp_state);
     target_arch = "x86_64",
     target_arch = "arm",
     target_arch = "aarch64",
-    target_arch = "s390"
+    target_arch = "s390x"
 ))]
 ioctl_iow_nr!(KVM_SET_MP_STATE, KVMIO, 0x99, kvm_mp_state);
 /* Available with KVM_CAP_USER_NMI */


### PR DESCRIPTION
### Summary of the PR

- Replace `s390` with `s390x`, `ppc` with `powerpc` in `target_arch`predicates.
- Add `has_sev` to expected attribute.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
