### PR TITLE
Add kvm guest memfd related capabilities

### DIFF
--- a/kvm-ioctls/CHANGELOG.md
+++ b/kvm-ioctls/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [[#288](https://github.com/rust-vmm/kvm-ioctls/pull/288)]: Introduce `Cap::GuestMemfd`, `Cap::MemoryAttributes` and 
    `Cap::UserMemory2` capabilities enum variants for use with `VmFd::check_extension`.
+- [[#288](https://github.com/rust-vmm/kvm-ioctls/pull/288)]: Introduce `VmFd::check_extension_raw` and `VmFd::check_extension_int` to allow `KVM_CHECK_EXTENSION` to return integer.
 
 ### Fixed
 

--- a/kvm-ioctls/src/ioctls/vm.rs
+++ b/kvm-ioctls/src/ioctls/vm.rs
@@ -1402,10 +1402,50 @@ impl VmFd {
     /// Wrapper over `KVM_CHECK_EXTENSION`.
     ///
     /// Returns 0 if the capability is not available and a positive integer otherwise.
-    fn check_extension_int(&self, c: Cap) -> i32 {
-        // SAFETY: Safe because we know that our file is a VM fd and that the extension is one of
-        // the ones defined by kernel.
-        unsafe { ioctl_with_val(self, KVM_CHECK_EXTENSION(), c as c_ulong) }
+    /// See the documentation for `KVM_CHECK_EXTENSION`.
+    ///
+    /// # Arguments
+    ///
+    /// * `c` - KVM capability to check.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use kvm_ioctls::Kvm;
+    /// use kvm_ioctls::Cap;
+    ///
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// assert!(vm.check_extension_int(Cap::MaxVcpus) > 0);
+    /// ```
+    pub fn check_extension_int(&self, c: Cap) -> i32 {
+        self.check_extension_raw(c as c_ulong)
+    }
+
+    /// Wrapper over `KVM_CHECK_EXTENSION`.
+    ///
+    /// Returns 0 if the capability is not available and a positive integer otherwise.
+    /// See the documentation for `KVM_CHECK_EXTENSION`.
+    ///
+    /// # Arguments
+    ///
+    /// * `c` - KVM capability to check in a form of a raw integer.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use kvm_ioctls::Kvm;
+    /// # use std::os::raw::c_ulong;
+    /// use kvm_ioctls::Cap;
+    ///
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// assert!(vm.check_extension_raw(Cap::MaxVcpus as c_ulong) > 0);
+    /// ```
+    pub fn check_extension_raw(&self, c: c_ulong) -> i32 {
+        // SAFETY: Safe because we know that our file is a KVM fd.
+        // If `c` is not a known kernel extension, kernel will return 0.
+        unsafe { ioctl_with_val(self, KVM_CHECK_EXTENSION(), c) }
     }
 
     /// Checks if a particular `Cap` is available.


### PR DESCRIPTION
### Summary of the PR

The capabilities are required to properly setup a guest_memfd to provide better host and guest memory isolation. The memory attributes capability returns an integer with each bits representing different configs. For example, the return integer & KVM_MEMORY_ATTRIBUTE_PRIVATE > 0 means the vm is capable of setting memory pages to private.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
