### PR TITLE
Drop `arm` and `x86` 32-bit architecture support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- [[#289](https://github.com/rust-vmm/kvm-ioctls/pull/289)]: Drop `x86` and `arm` support.
 - [[#275](https://github.com/rust-vmm/kvm-ioctls/pull/275)]: Introduce `riscv64` ioctls.
 
 ### Changed

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -42,39 +42,33 @@ pub enum Cap {
     DestroyMemoryRegionWorks = KVM_CAP_DESTROY_MEMORY_REGION_WORKS,
     UserNmi = KVM_CAP_USER_NMI,
     #[cfg(any(
-        target_arch = "x86",
         target_arch = "x86_64",
         target_arch = "arm",
         target_arch = "aarch64",
         target_arch = "s390x"
     ))]
     SetGuestDebug = KVM_CAP_SET_GUEST_DEBUG,
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     ReinjectControl = KVM_CAP_REINJECT_CONTROL,
     IrqRouting = KVM_CAP_IRQ_ROUTING,
     IrqInjectStatus = KVM_CAP_IRQ_INJECT_STATUS,
     AssignDevIrq = KVM_CAP_ASSIGN_DEV_IRQ,
     JoinMemoryRegionsWorks = KVM_CAP_JOIN_MEMORY_REGIONS_WORKS,
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     Mce = KVM_CAP_MCE,
     Irqfd = KVM_CAP_IRQFD,
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     Pit2 = KVM_CAP_PIT2,
     SetBootCpuId = KVM_CAP_SET_BOOT_CPU_ID,
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     PitState2 = KVM_CAP_PIT_STATE2,
     Ioeventfd = KVM_CAP_IOEVENTFD,
     SetIdentityMapAddr = KVM_CAP_SET_IDENTITY_MAP_ADDR,
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     XenHvm = KVM_CAP_XEN_HVM,
     AdjustClock = KVM_CAP_ADJUST_CLOCK,
     InternalErrorData = KVM_CAP_INTERNAL_ERROR_DATA,
-    #[cfg(any(
-        target_arch = "x86",
-        target_arch = "x86_64",
-        target_arch = "arm",
-        target_arch = "aarch64"
-    ))]
+    #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
     VcpuEvents = KVM_CAP_VCPU_EVENTS,
     S390Psw = KVM_CAP_S390_PSW,
     PpcSegstate = KVM_CAP_PPC_SEGSTATE,
@@ -84,15 +78,15 @@ pub enum Cap {
     PciSegment = KVM_CAP_PCI_SEGMENT,
     PpcPairedSingles = KVM_CAP_PPC_PAIRED_SINGLES,
     IntrShadow = KVM_CAP_INTR_SHADOW,
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     Debugregs = KVM_CAP_DEBUGREGS,
     X86RobustSinglestep = KVM_CAP_X86_ROBUST_SINGLESTEP,
     PpcOsi = KVM_CAP_PPC_OSI,
     PpcUnsetIrq = KVM_CAP_PPC_UNSET_IRQ,
     EnableCap = KVM_CAP_ENABLE_CAP,
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     Xsave = KVM_CAP_XSAVE,
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     Xcrs = KVM_CAP_XCRS,
     PpcGetPvinfo = KVM_CAP_PPC_GET_PVINFO,
     PpcIrqLevel = KVM_CAP_PPC_IRQ_LEVEL,
@@ -145,9 +139,9 @@ pub enum Cap {
     PpcEnableHcall = KVM_CAP_PPC_ENABLE_HCALL,
     CheckExtensionVm = KVM_CAP_CHECK_EXTENSION_VM,
     S390UserSigp = KVM_CAP_S390_USER_SIGP,
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     X86Smm = KVM_CAP_X86_SMM,
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     SplitIrqchip = KVM_CAP_SPLIT_IRQCHIP,
     ArmPmuV3 = KVM_CAP_ARM_PMU_V3,
     ImmediateExit = KVM_CAP_IMMEDIATE_EXIT,
@@ -165,10 +159,10 @@ pub enum Cap {
     ArmPtrAuthAddress = KVM_CAP_ARM_PTRAUTH_ADDRESS,
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     ArmPtrAuthGeneric = KVM_CAP_ARM_PTRAUTH_GENERIC,
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     X86UserSpaceMsr = KVM_CAP_X86_USER_SPACE_MSR,
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     ExitHypercall = KVM_CAP_EXIT_HYPERCALL,
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     MemoryFaultInfo = KVM_CAP_MEMORY_FAULT_INFO,
 }

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -41,12 +41,7 @@ pub enum Cap {
     Iommu = KVM_CAP_IOMMU,
     DestroyMemoryRegionWorks = KVM_CAP_DESTROY_MEMORY_REGION_WORKS,
     UserNmi = KVM_CAP_USER_NMI,
-    #[cfg(any(
-        target_arch = "x86_64",
-        target_arch = "arm",
-        target_arch = "aarch64",
-        target_arch = "s390x"
-    ))]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "s390x"))]
     SetGuestDebug = KVM_CAP_SET_GUEST_DEBUG,
     #[cfg(target_arch = "x86_64")]
     ReinjectControl = KVM_CAP_REINJECT_CONTROL,
@@ -68,7 +63,7 @@ pub enum Cap {
     XenHvm = KVM_CAP_XEN_HVM,
     AdjustClock = KVM_CAP_ADJUST_CLOCK,
     InternalErrorData = KVM_CAP_INTERNAL_ERROR_DATA,
-    #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     VcpuEvents = KVM_CAP_VCPU_EVENTS,
     S390Psw = KVM_CAP_S390_PSW,
     PpcSegstate = KVM_CAP_PPC_SEGSTATE,
@@ -155,9 +150,9 @@ pub enum Cap {
     CoalescedPio = KVM_CAP_COALESCED_PIO,
     #[cfg(target_arch = "aarch64")]
     ArmSve = KVM_CAP_ARM_SVE,
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     ArmPtrAuthAddress = KVM_CAP_ARM_PTRAUTH_ADDRESS,
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     ArmPtrAuthGeneric = KVM_CAP_ARM_PTRAUTH_GENERIC,
     #[cfg(target_arch = "x86_64")]
     X86UserSpaceMsr = KVM_CAP_X86_USER_SPACE_MSR,

--- a/src/ioctls/device.rs
+++ b/src/ioctls/device.rs
@@ -202,7 +202,7 @@ mod tests {
     #![allow(clippy::undocumented_unsafe_blocks)]
     use super::*;
     use crate::ioctls::system::Kvm;
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     use kvm_bindings::{
         kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3, kvm_device_type_KVM_DEV_TYPE_VFIO,
         KVM_DEV_VFIO_GROUP, KVM_DEV_VFIO_GROUP_ADD,
@@ -213,7 +213,7 @@ mod tests {
     use kvm_bindings::KVM_CREATE_DEVICE_TEST;
 
     #[test]
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     fn test_create_device() {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();

--- a/src/ioctls/system.rs
+++ b/src/ioctls/system.rs
@@ -16,10 +16,10 @@ use crate::ioctls::Result;
 use crate::kvm_ioctls::*;
 #[cfg(target_arch = "aarch64")]
 use kvm_bindings::KVM_VM_TYPE_ARM_IPA_SIZE_MASK;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 use kvm_bindings::{CpuId, MsrList, Msrs, KVM_MAX_CPUID_ENTRIES, KVM_MAX_MSR_ENTRIES};
 use vmm_sys_util::errno;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 use vmm_sys_util::ioctl::ioctl_with_mut_ptr;
 use vmm_sys_util::ioctl::{ioctl, ioctl_with_val};
 
@@ -352,7 +352,7 @@ impl Kvm {
         }
     }
 
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     fn get_cpuid(&self, kind: u64, num_entries: usize) -> Result<CpuId> {
         if num_entries > KVM_MAX_CPUID_ENTRIES {
             // Returns the same error the underlying `ioctl` would have sent.
@@ -395,7 +395,7 @@ impl Kvm {
     /// let cpuid_entries = cpuid.as_mut_slice();
     /// assert!(cpuid_entries.len() <= KVM_MAX_CPUID_ENTRIES);
     /// ```
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     pub fn get_emulated_cpuid(&self, num_entries: usize) -> Result<CpuId> {
         self.get_cpuid(KVM_GET_EMULATED_CPUID(), num_entries)
     }
@@ -424,7 +424,7 @@ impl Kvm {
     /// let cpuid_entries = cpuid.as_mut_slice();
     /// assert!(cpuid_entries.len() <= KVM_MAX_CPUID_ENTRIES);
     /// ```
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     pub fn get_supported_cpuid(&self, num_entries: usize) -> Result<CpuId> {
         self.get_cpuid(KVM_GET_SUPPORTED_CPUID(), num_entries)
     }
@@ -441,7 +441,7 @@ impl Kvm {
     /// let kvm = Kvm::new().unwrap();
     /// let msr_index_list = kvm.get_msr_index_list().unwrap();
     /// ```
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     pub fn get_msr_index_list(&self) -> Result<MsrList> {
         let mut msr_list =
             MsrList::new(KVM_MAX_MSR_ENTRIES).map_err(|_| errno::Error::new(libc::ENOMEM))?;
@@ -477,7 +477,7 @@ impl Kvm {
     /// let kvm = Kvm::new().unwrap();
     /// let msr_feature_index_list = kvm.get_msr_feature_index_list().unwrap();
     /// ```
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     pub fn get_msr_feature_index_list(&self) -> Result<MsrList> {
         let mut msr_list =
             MsrList::new(KVM_MAX_MSR_ENTRIES).map_err(|_| errno::Error::new(libc::ENOMEM))?;
@@ -531,7 +531,7 @@ impl Kvm {
     /// .unwrap();
     /// let ret = kvm.get_msrs(&mut msrs).unwrap();
     /// ```
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     pub fn get_msrs(&self, msrs: &mut Msrs) -> Result<usize> {
         // SAFETY: Here we trust the kernel not to read past the end of the kvm_msrs struct.
         let ret = unsafe { ioctl_with_mut_ptr(self, KVM_GET_MSRS(), msrs.as_mut_fam_struct_ptr()) };
@@ -731,7 +731,7 @@ mod tests {
     use super::*;
     use libc::{fcntl, FD_CLOEXEC, F_GETFD};
     use std::os::fd::IntoRawFd;
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     use vmm_sys_util::fam::FamStruct;
 
     #[test]
@@ -867,7 +867,7 @@ mod tests {
         }
     }
 
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     #[test]
     fn test_get_supported_cpuid() {
         let kvm = Kvm::new().unwrap();
@@ -882,7 +882,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     fn test_get_emulated_cpuid() {
         let kvm = Kvm::new().unwrap();
         let mut cpuid = kvm.get_emulated_cpuid(KVM_MAX_CPUID_ENTRIES).unwrap();
@@ -895,7 +895,7 @@ mod tests {
         cpuid_err.unwrap_err();
     }
 
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     #[test]
     fn test_cpuid_clone() {
         let kvm = Kvm::new().unwrap();
@@ -910,7 +910,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     fn get_msr_index_list() {
         let kvm = Kvm::new().unwrap();
         let msr_list = kvm.get_msr_index_list().unwrap();
@@ -918,7 +918,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     fn get_msr_feature_index_list() {
         let kvm = Kvm::new().unwrap();
         let msr_feature_index_list = kvm.get_msr_feature_index_list().unwrap();
@@ -926,7 +926,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     fn get_msrs() {
         use kvm_bindings::kvm_msr_entry;
 
@@ -961,7 +961,7 @@ mod tests {
         );
         assert_eq!(faulty_kvm.get_nr_vcpus(), 4);
         assert_eq!(faulty_kvm.get_nr_memslots(), 32);
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[cfg(target_arch = "x86_64")]
         {
             assert_eq!(
                 faulty_kvm.get_emulated_cpuid(4).err().unwrap().errno(),

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -20,7 +20,7 @@ use vmm_sys_util::ioctl::{ioctl, ioctl_with_mut_ref, ioctl_with_ref};
 use vmm_sys_util::ioctl::{ioctl_with_mut_ptr, ioctl_with_ptr, ioctl_with_val};
 
 /// Helper method to obtain the size of the register through its id
-#[cfg(any(target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64"))]
+#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 pub fn reg_size(reg_id: u64) -> usize {
     2_usize.pow(((reg_id & KVM_REG_SIZE_MASK) >> KVM_REG_SIZE_SHIFT) as u32)
 }
@@ -224,7 +224,7 @@ impl VcpuFd {
     /// let vcpu = vm.create_vcpu(0).unwrap();
     /// let regs = vcpu.get_regs().unwrap();
     /// ```
-    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64")))]
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
     pub fn get_regs(&self) -> Result<kvm_regs> {
         let mut regs = kvm_regs::default();
         // SAFETY: Safe because we know that our file is a vCPU fd, we know the kernel will only
@@ -340,7 +340,7 @@ impl VcpuFd {
     /// regs.rip = 0x100;
     /// vcpu.set_regs(&regs).unwrap();
     /// ```
-    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64")))]
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
     pub fn set_regs(&self, regs: &kvm_regs) -> Result<()> {
         // SAFETY: Safe because we know that our file is a vCPU fd, we know the kernel will only
         // read the correct amount of memory from our pointer, and we verify the return result.
@@ -788,7 +788,6 @@ impl VcpuFd {
     /// ```
     #[cfg(any(
         target_arch = "x86_64",
-        target_arch = "arm",
         target_arch = "aarch64",
         target_arch = "riscv64",
         target_arch = "s390x"
@@ -826,7 +825,6 @@ impl VcpuFd {
     /// ```
     #[cfg(any(
         target_arch = "x86_64",
-        target_arch = "arm",
         target_arch = "aarch64",
         target_arch = "riscv64",
         target_arch = "s390x"
@@ -1045,7 +1043,7 @@ impl VcpuFd {
     ///     let vcpu_events = vcpu.get_vcpu_events().unwrap();
     /// }
     /// ```
-    #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn get_vcpu_events(&self) -> Result<kvm_vcpu_events> {
         let mut vcpu_events = Default::default();
         // SAFETY: Here we trust the kernel not to read past the end of the kvm_vcpu_events struct.
@@ -1079,7 +1077,7 @@ impl VcpuFd {
     ///     vcpu.set_vcpu_events(&vcpu_events).unwrap();
     /// }
     /// ```
-    #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn set_vcpu_events(&self, vcpu_events: &kvm_vcpu_events) -> Result<()> {
         // SAFETY: Here we trust the kernel not to read past the end of the kvm_vcpu_events struct.
         let ret = unsafe { ioctl_with_ref(self, KVM_SET_VCPU_EVENTS(), vcpu_events) };
@@ -1115,7 +1113,7 @@ impl VcpuFd {
     /// vm.get_preferred_target(&mut kvi).unwrap();
     /// vcpu.vcpu_init(&kvi).unwrap();
     /// ```
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     pub fn vcpu_init(&self, kvi: &kvm_vcpu_init) -> Result<()> {
         // SAFETY: This is safe because we allocated the struct and we know the kernel will read
         // exactly the size of the struct.
@@ -1203,7 +1201,7 @@ impl VcpuFd {
     /// let vcpu = vm.create_vcpu(0).unwrap();
     ///
     /// // KVM_GET_REG_LIST on Aarch64 demands that the vcpus be initialized.
-    /// #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    /// #[cfg(target_arch = "aarch64")]
     /// {
     ///     let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
     ///     vm.get_preferred_target(&mut kvi).unwrap();
@@ -1214,7 +1212,7 @@ impl VcpuFd {
     ///     assert!(reg_list.as_fam_struct_ref().n > 0);
     /// }
     /// ```
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64"))]
+    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     pub fn get_reg_list(&self, reg_list: &mut RegList) -> Result<()> {
         let ret =
             // SAFETY: This is safe because we allocated the struct and we trust the kernel will read
@@ -1291,7 +1289,7 @@ impl VcpuFd {
     ///
     /// `data` should be equal or bigger then the register size
     /// oterwise function will return EINVAL error
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64"))]
+    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     pub fn set_one_reg(&self, reg_id: u64, data: &[u8]) -> Result<usize> {
         let reg_size = reg_size(reg_id);
         if data.len() < reg_size {
@@ -1323,7 +1321,7 @@ impl VcpuFd {
     ///
     /// `data` should be equal or bigger then the register size
     /// oterwise function will return EINVAL error
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64"))]
+    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     pub fn get_one_reg(&self, reg_id: u64, data: &mut [u8]) -> Result<usize> {
         let reg_size = reg_size(reg_id);
         if data.len() < reg_size {
@@ -1965,7 +1963,7 @@ mod tests {
     extern crate byteorder;
 
     use super::*;
-    #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     use crate::cap::Cap;
     use crate::ioctls::system::Kvm;
     use std::ptr::NonNull;
@@ -2212,7 +2210,6 @@ mod tests {
 
     #[cfg(any(
         target_arch = "x86_64",
-        target_arch = "arm",
         target_arch = "aarch64",
         target_arch = "riscv64",
         target_arch = "s390x"
@@ -2264,7 +2261,7 @@ mod tests {
         assert_eq!(debugregs, other_debugregs);
     }
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     #[test]
     fn vcpu_events_test() {
         let kvm = Kvm::new().unwrap();
@@ -2606,7 +2603,6 @@ mod tests {
     #[test]
     #[cfg(any(
         target_arch = "x86_64",
-        target_arch = "arm",
         target_arch = "aarch64",
         target_arch = "riscv64"
     ))]
@@ -2635,12 +2631,12 @@ mod tests {
                 .errno(),
             badf_errno
         );
-        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
         assert_eq!(
             faulty_vcpu_fd.get_vcpu_events().unwrap_err().errno(),
             badf_errno
         );
-        #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
         assert_eq!(
             faulty_vcpu_fd
                 .set_vcpu_events(&kvm_vcpu_events::default())
@@ -2924,7 +2920,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn test_get_preferred_target() {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
@@ -2938,7 +2934,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn test_set_one_reg() {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
@@ -2964,7 +2960,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn test_get_one_reg() {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
@@ -3000,7 +2996,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn test_get_reg_list() {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -24,7 +24,7 @@ use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::EventFd;
 #[cfg(target_arch = "x86_64")]
 use vmm_sys_util::ioctl::ioctl_with_mut_ptr;
-#[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use vmm_sys_util::ioctl::{ioctl, ioctl_with_mut_ref};
 use vmm_sys_util::ioctl::{ioctl_with_ref, ioctl_with_val};
 
@@ -278,7 +278,7 @@ impl VmFd {
     ///
     /// #[cfg(target_arch = "x86_64")]
     /// vm.create_irq_chip().unwrap();
-    /// #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    /// #[cfg(target_arch = "aarch64")]
     /// {
     ///     use kvm_bindings::{
     ///         kvm_create_device, kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2, KVM_CREATE_DEVICE_TEST,
@@ -293,7 +293,7 @@ impl VmFd {
     ///     }
     /// }
     /// ```
-    #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn create_irq_chip(&self) -> Result<()> {
         // SAFETY: Safe because we know that our file is a VM fd and we verify the return result.
         let ret = unsafe { ioctl(self, KVM_CREATE_IRQCHIP()) };
@@ -578,7 +578,6 @@ impl VmFd {
     /// ```
     #[cfg(any(
         target_arch = "x86_64",
-        target_arch = "arm",
         target_arch = "aarch64",
         target_arch = "riscv64"
     ))]
@@ -634,7 +633,6 @@ impl VmFd {
     /// ```
     #[cfg(any(
         target_arch = "x86_64",
-        target_arch = "arm",
         target_arch = "aarch64",
         target_arch = "riscv64"
     ))]
@@ -982,7 +980,6 @@ impl VmFd {
     /// ```
     #[cfg(any(
         target_arch = "x86_64",
-        target_arch = "arm",
         target_arch = "aarch64",
         target_arch = "riscv64"
     ))]
@@ -1034,7 +1031,6 @@ impl VmFd {
     /// ```
     #[cfg(any(
         target_arch = "x86_64",
-        target_arch = "arm",
         target_arch = "aarch64",
         target_arch = "riscv64"
     ))]
@@ -1093,7 +1089,6 @@ impl VmFd {
     /// ```
     #[cfg(any(
         target_arch = "x86_64",
-        target_arch = "arm",
         target_arch = "aarch64",
         target_arch = "riscv64"
     ))]
@@ -1142,7 +1137,7 @@ impl VmFd {
     ///     // For Arm architectures, the IRQ controllers need to be setup first.
     ///     // Details please refer to the kernel documentation.
     ///     // https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt
-    /// #   #[cfg(any(target_arch = "arm", target_arch = "aarch64"))] {
+    /// #   #[cfg(target_arch = "aarch64")] {
     /// #       vm_fd.create_vcpu(0).unwrap();
     /// #       // ... rest of setup for Arm goes here
     /// #   }
@@ -1156,7 +1151,7 @@ impl VmFd {
     ///     vm.set_irq_line(4, true);
     ///     // ...
     /// }
-    /// #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    /// #[cfg(target_arch = "aarch64")]
     /// {
     ///     vm.set_irq_line(0x01_00_0020, true);
     ///     // ....
@@ -1164,7 +1159,6 @@ impl VmFd {
     /// ```
     #[cfg(any(
         target_arch = "x86_64",
-        target_arch = "arm",
         target_arch = "aarch64",
         target_arch = "riscv64"
     ))]
@@ -1288,7 +1282,7 @@ impl VmFd {
     /// let mut device = kvm_bindings::kvm_create_device {
     ///     #[cfg(target_arch = "x86_64")]
     ///     type_: kvm_device_type_KVM_DEV_TYPE_VFIO,
-    ///     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    ///     #[cfg(target_arch = "aarch64")]
     ///     type_: kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3,
     ///     #[cfg(target_arch = "riscv64")]
     ///     type_: kvm_device_type_KVM_DEV_TYPE_RISCV_AIA,
@@ -1300,7 +1294,7 @@ impl VmFd {
     /// let device_fd = vm.create_device(&mut device).unwrap_or_else(|_| {
     ///     #[cfg(target_arch = "x86_64")]
     ///     panic!("Cannot create VFIO device.");
-    ///     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    ///     #[cfg(target_arch = "aarch64")]
     ///     {
     ///         device.type_ = kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2;
     ///         vm.create_device(&mut device)
@@ -1344,7 +1338,7 @@ impl VmFd {
     /// let mut kvi = kvm_vcpu_init::default();
     /// vm.get_preferred_target(&mut kvi).unwrap();
     /// ```
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     pub fn get_preferred_target(&self, kvi: &mut kvm_vcpu_init) -> Result<()> {
         // SAFETY: The ioctl is safe because we allocated the struct and we know the
         // kernel will write exactly the size of the struct.
@@ -1398,7 +1392,7 @@ impl VmFd {
     ///     vm.enable_cap(&cap).unwrap();
     /// }
     /// ```
-    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64")))]
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
     pub fn enable_cap(&self, cap: &kvm_enable_cap) -> Result<()> {
         // SAFETY: The ioctl is safe because we allocated the struct and we know the
         // kernel will write exactly the size of the struct.
@@ -1920,7 +1914,7 @@ impl AsRawFd for VmFd {
 /// * `vm` - The vm file descriptor.
 /// * `flags` - Flags to be passed to `KVM_CREATE_DEVICE`.
 #[cfg(test)]
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 pub(crate) fn create_gic_device(vm: &VmFd, flags: u32) -> DeviceFd {
     let mut gic_device = kvm_bindings::kvm_create_device {
         type_: kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3,
@@ -1944,7 +1938,7 @@ pub(crate) fn create_gic_device(vm: &VmFd, flags: u32) -> DeviceFd {
 /// * `vgic` - The vGIC file descriptor.
 /// * `nr_irqs` - Number of IRQs.
 #[cfg(test)]
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 pub(crate) fn set_supported_nr_irqs(vgic: &DeviceFd, nr_irqs: u32) {
     let vgic_attr = kvm_bindings::kvm_device_attr {
         group: kvm_bindings::KVM_DEV_ARM_VGIC_GRP_NR_IRQS,
@@ -1962,7 +1956,7 @@ pub(crate) fn set_supported_nr_irqs(vgic: &DeviceFd, nr_irqs: u32) {
 ///
 /// * `vgic` - The vGIC file descriptor.
 #[cfg(test)]
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 pub(crate) fn request_gic_init(vgic: &DeviceFd) {
     let vgic_attr = kvm_bindings::kvm_device_attr {
         group: kvm_bindings::KVM_DEV_ARM_VGIC_GRP_CTRL,
@@ -2124,7 +2118,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn test_irq_chip() {
         use Cap;
 
@@ -2590,7 +2584,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn test_get_preferred_target() {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
@@ -2604,7 +2598,6 @@ mod tests {
     #[test]
     #[cfg(any(
         target_arch = "x86_64",
-        target_arch = "arm",
         target_arch = "aarch64",
         target_arch = "riscv64"
     ))]
@@ -2616,7 +2609,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64")))]
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
     fn test_enable_cap_failure() {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
@@ -2653,7 +2646,6 @@ mod tests {
     #[test]
     #[cfg(any(
         target_arch = "x86_64",
-        target_arch = "arm",
         target_arch = "aarch64",
         target_arch = "riscv64"
     ))]

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -22,14 +22,9 @@ use crate::ioctls::{KvmRunWrapper, Result};
 use crate::kvm_ioctls::*;
 use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::EventFd;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 use vmm_sys_util::ioctl::ioctl_with_mut_ptr;
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    target_arch = "arm",
-    target_arch = "aarch64"
-))]
+#[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
 use vmm_sys_util::ioctl::{ioctl, ioctl_with_mut_ref};
 use vmm_sys_util::ioctl::{ioctl_with_ref, ioctl_with_val};
 
@@ -229,7 +224,7 @@ impl VmFd {
     /// let vm = kvm.create_vm().unwrap();
     /// vm.set_tss_address(0xfffb_d000).unwrap();
     /// ```
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     pub fn set_tss_address(&self, offset: usize) -> Result<()> {
         // SAFETY: Safe because we know that our file is a VM fd and we verify the return result.
         let ret = unsafe { ioctl_with_val(self, KVM_SET_TSS_ADDR(), offset as c_ulong) };
@@ -257,7 +252,7 @@ impl VmFd {
     /// let vm = kvm.create_vm().unwrap();
     /// vm.set_identity_map_address(0xfffb_c000).unwrap();
     /// ```
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     pub fn set_identity_map_address(&self, address: u64) -> Result<()> {
         // SAFETY: Safe because we know that our file is a VM fd and we verify the return result.
         let ret = unsafe { ioctl_with_ref(self, KVM_SET_IDENTITY_MAP_ADDR(), &address) };
@@ -281,7 +276,7 @@ impl VmFd {
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     ///
-    /// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    /// #[cfg(target_arch = "x86_64")]
     /// vm.create_irq_chip().unwrap();
     /// #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     /// {
@@ -298,12 +293,7 @@ impl VmFd {
     ///     }
     /// }
     /// ```
-    #[cfg(any(
-        target_arch = "x86",
-        target_arch = "x86_64",
-        target_arch = "arm",
-        target_arch = "aarch64"
-    ))]
+    #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
     pub fn create_irq_chip(&self) -> Result<()> {
         // SAFETY: Safe because we know that our file is a VM fd and we verify the return result.
         let ret = unsafe { ioctl(self, KVM_CREATE_IRQCHIP()) };
@@ -338,7 +328,7 @@ impl VmFd {
     /// irqchip.chip_id = KVM_IRQCHIP_PIC_MASTER;
     /// vm.get_irqchip(&mut irqchip).unwrap();
     /// ```
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     pub fn get_irqchip(&self, irqchip: &mut kvm_irqchip) -> Result<()> {
         // SAFETY: Here we trust the kernel not to read past the end of the kvm_irqchip struct.
         let ret = unsafe { ioctl_with_mut_ref(self, KVM_GET_IRQCHIP(), irqchip) };
@@ -374,7 +364,7 @@ impl VmFd {
     /// // Your `irqchip` manipulation here.
     /// vm.set_irqchip(&mut irqchip).unwrap();
     /// ```
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     pub fn set_irqchip(&self, irqchip: &kvm_irqchip) -> Result<()> {
         // SAFETY: Here we trust the kernel not to read past the end of the kvm_irqchip struct.
         let ret = unsafe { ioctl_with_ref(self, KVM_SET_IRQCHIP(), irqchip) };
@@ -405,7 +395,7 @@ impl VmFd {
     /// let pit_config = kvm_pit_config::default();
     /// vm.create_pit2(pit_config).unwrap();
     /// ```
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     pub fn create_pit2(&self, pit_config: kvm_pit_config) -> Result<()> {
         // SAFETY: Safe because we know that our file is a VM fd, we know the kernel will only read
         // the correct amount of memory from our pointer, and we verify the return result.
@@ -441,7 +431,7 @@ impl VmFd {
     /// vm.create_pit2(pit_config).unwrap();
     /// let pitstate = vm.get_pit2().unwrap();
     /// ```
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     pub fn get_pit2(&self) -> Result<kvm_pit_state2> {
         let mut pitstate = Default::default();
         // SAFETY: Here we trust the kernel not to read past the end of the kvm_pit_state2 struct.
@@ -479,7 +469,7 @@ impl VmFd {
     /// // Your `pitstate` manipulation here.
     /// vm.set_pit2(&mut pitstate).unwrap();
     /// ```
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     pub fn set_pit2(&self, pitstate: &kvm_pit_state2) -> Result<()> {
         // SAFETY: Here we trust the kernel not to read past the end of the kvm_pit_state2 struct.
         let ret = unsafe { ioctl_with_ref(self, KVM_SET_PIT2(), pitstate) };
@@ -508,7 +498,7 @@ impl VmFd {
     /// let vm = kvm.create_vm().unwrap();
     /// let clock = vm.get_clock().unwrap();
     /// ```
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     pub fn get_clock(&self) -> Result<kvm_clock_data> {
         let mut clock = Default::default();
         // SAFETY: Here we trust the kernel not to read past the end of the kvm_clock_data struct.
@@ -541,7 +531,7 @@ impl VmFd {
     /// let mut clock = kvm_clock_data::default();
     /// vm.set_clock(&mut clock).unwrap();
     /// ```
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     pub fn set_clock(&self, clock: &kvm_clock_data) -> Result<()> {
         // SAFETY: Here we trust the kernel not to read past the end of the kvm_clock_data struct.
         let ret = unsafe { ioctl_with_ref(self, KVM_SET_CLOCK(), clock) };
@@ -582,12 +572,11 @@ impl VmFd {
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     /// let msi = kvm_msi::default();
-    /// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    /// #[cfg(target_arch = "x86_64")]
     /// vm.create_irq_chip().unwrap();
     /// //vm.signal_msi(msi).unwrap();
     /// ```
     #[cfg(any(
-        target_arch = "x86",
         target_arch = "x86_64",
         target_arch = "arm",
         target_arch = "aarch64",
@@ -629,7 +618,7 @@ impl VmFd {
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     ///
-    /// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    /// #[cfg(target_arch = "x86_64")]
     /// vm.create_irq_chip().unwrap();
     ///
     /// #[cfg(target_arch = "riscv64")]
@@ -644,7 +633,6 @@ impl VmFd {
     /// vm.set_gsi_routing(&irq_routing).unwrap();
     /// ```
     #[cfg(any(
-        target_arch = "x86",
         target_arch = "x86_64",
         target_arch = "arm",
         target_arch = "aarch64",
@@ -853,7 +841,7 @@ impl VmFd {
     /// };
     /// unsafe { vm.set_user_memory_region(mem_region).unwrap() };
     ///
-    /// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    /// #[cfg(target_arch = "x86_64")]
     /// // ASM code that just forces a MMIO Write.
     /// let asm_code = [0xc6, 0x06, 0x00, 0x80, 0x00];
     /// #[cfg(target_arch = "aarch64")]
@@ -880,7 +868,7 @@ impl VmFd {
     ///
     /// let mut vcpu_fd = vm.create_vcpu(0).unwrap();
     ///
-    /// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    /// #[cfg(target_arch = "x86_64")]
     /// {
     ///     // x86_64 specific registry setup.
     ///     let mut vcpu_sregs = vcpu_fd.get_sregs().unwrap();
@@ -986,14 +974,13 @@ impl VmFd {
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     /// let evtfd = EventFd::new(EFD_NONBLOCK).unwrap();
-    /// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    /// #[cfg(target_arch = "x86_64")]
     /// {
     ///     vm.create_irq_chip().unwrap();
     ///     vm.register_irqfd(&evtfd, 0).unwrap();
     /// }
     /// ```
     #[cfg(any(
-        target_arch = "x86",
         target_arch = "x86_64",
         target_arch = "arm",
         target_arch = "aarch64",
@@ -1038,7 +1025,7 @@ impl VmFd {
     /// let vm = kvm.create_vm().unwrap();
     /// let evtfd = EventFd::new(EFD_NONBLOCK).unwrap();
     /// let resamplefd = EventFd::new(EFD_NONBLOCK).unwrap();
-    /// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    /// #[cfg(target_arch = "x86_64")]
     /// {
     ///     vm.create_irq_chip().unwrap();
     ///     vm.register_irqfd_with_resample(&evtfd, &resamplefd, 0)
@@ -1046,7 +1033,6 @@ impl VmFd {
     /// }
     /// ```
     #[cfg(any(
-        target_arch = "x86",
         target_arch = "x86_64",
         target_arch = "arm",
         target_arch = "aarch64",
@@ -1095,7 +1081,7 @@ impl VmFd {
     /// let vm = kvm.create_vm().unwrap();
     /// let evtfd = EventFd::new(EFD_NONBLOCK).unwrap();
     /// let resamplefd = EventFd::new(EFD_NONBLOCK).unwrap();
-    /// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    /// #[cfg(target_arch = "x86_64")]
     /// {
     ///     vm.create_irq_chip().unwrap();
     ///     vm.register_irqfd(&evtfd, 0).unwrap();
@@ -1106,7 +1092,6 @@ impl VmFd {
     /// }
     /// ```
     #[cfg(any(
-        target_arch = "x86",
         target_arch = "x86_64",
         target_arch = "arm",
         target_arch = "aarch64",
@@ -1152,7 +1137,7 @@ impl VmFd {
     /// fn arch_setup(vm_fd: &VmFd) {
     ///     // Arch-specific setup:
     ///     // For x86 architectures, it simply means calling vm.create_irq_chip().unwrap().
-    /// #   #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    /// #   #[cfg(target_arch = "x86_64")]
     /// #   vm_fd.create_irq_chip().unwrap();
     ///     // For Arm architectures, the IRQ controllers need to be setup first.
     ///     // Details please refer to the kernel documentation.
@@ -1166,7 +1151,7 @@ impl VmFd {
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     /// arch_setup(&vm);
-    /// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    /// #[cfg(target_arch = "x86_64")]
     /// {
     ///     vm.set_irq_line(4, true);
     ///     // ...
@@ -1178,7 +1163,6 @@ impl VmFd {
     /// }
     /// ```
     #[cfg(any(
-        target_arch = "x86",
         target_arch = "x86_64",
         target_arch = "arm",
         target_arch = "aarch64",
@@ -1302,7 +1286,7 @@ impl VmFd {
     /// // whether the device type is supported. This will not create the device.
     /// // To create the device the flag needs to be removed.
     /// let mut device = kvm_bindings::kvm_create_device {
-    ///     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    ///     #[cfg(target_arch = "x86_64")]
     ///     type_: kvm_device_type_KVM_DEV_TYPE_VFIO,
     ///     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     ///     type_: kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3,
@@ -1314,7 +1298,7 @@ impl VmFd {
     /// // On ARM, creating VGICv3 may fail due to hardware dependency.
     /// // Retry to create VGICv2 in that case.
     /// let device_fd = vm.create_device(&mut device).unwrap_or_else(|_| {
-    ///     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    ///     #[cfg(target_arch = "x86_64")]
     ///     panic!("Cannot create VFIO device.");
     ///     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     ///     {
@@ -1397,7 +1381,7 @@ impl VmFd {
     /// let mut cap: kvm_enable_cap = Default::default();
     /// // This example cannot enable an arm/aarch64 capability since there
     /// // is no capability available for these architectures.
-    /// if cfg!(target_arch = "x86") || cfg!(target_arch = "x86_64") {
+    /// if cfg!(target_arch = "x86_64") {
     ///     cap.cap = KVM_CAP_SPLIT_IRQCHIP;
     ///     // As per the KVM documentation, KVM_CAP_SPLIT_IRQCHIP only emulates
     ///     // the local APIC in kernel, expecting that a userspace IOAPIC will
@@ -1650,7 +1634,7 @@ impl VmFd {
     /// let mut init: kvm_sev_cmd = Default::default();
     /// unsafe { vm.encrypt_op(&mut init).unwrap() };
     /// ```
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     pub unsafe fn encrypt_op<T>(&self, op: *mut T) -> Result<()> {
         let ret = ioctl_with_mut_ptr(self, KVM_MEMORY_ENCRYPT_OP(), op);
         if ret == 0 {
@@ -1692,7 +1676,7 @@ impl VmFd {
     /// let mut init: kvm_sev_cmd = Default::default();
     /// vm.encrypt_op_sev(&mut init).unwrap();
     /// ```
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     pub fn encrypt_op_sev(&self, op: &mut kvm_sev_cmd) -> Result<()> {
         // SAFETY: Safe because we know that kernel will only read the correct amount of memory
         // from our pointer and we know where it will write it (op.error).
@@ -1762,7 +1746,7 @@ impl VmFd {
     /// };
     /// vm.register_enc_memory_region(&memory_region).unwrap();
     /// ```
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     pub fn register_enc_memory_region(&self, memory_region: &kvm_enc_region) -> Result<()> {
         // SAFETY: Safe because we know that our file is a VM fd, we know the kernel will only read
         // the correct amount of memory from our pointer, and we verify the return result.
@@ -1839,7 +1823,7 @@ impl VmFd {
     /// vm.register_enc_memory_region(&memory_region).unwrap();
     /// vm.unregister_enc_memory_region(&memory_region).unwrap();
     /// ```
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     pub fn unregister_enc_memory_region(&self, memory_region: &kvm_enc_region) -> Result<()> {
         // SAFETY: Safe because we know that our file is a VM fd, we know the kernel will only read
         // the correct amount of memory from our pointer, and we verify the return result.
@@ -2051,7 +2035,7 @@ mod tests {
     use super::*;
     use crate::Kvm;
 
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     use std::{fs::OpenOptions, os::fd::IntoRawFd, ptr::null_mut};
 
     use libc::EFD_NONBLOCK;
@@ -2089,7 +2073,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     fn test_set_tss_address() {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
@@ -2097,7 +2081,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     fn test_set_identity_map_address() {
         let kvm = Kvm::new().unwrap();
         if kvm.check_extension(Cap::SetIdentityMapAddr) {
@@ -2110,7 +2094,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     fn test_irq_chip() {
         use Cap;
 
@@ -2162,7 +2146,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     fn test_pit2() {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
@@ -2181,7 +2165,7 @@ mod tests {
         assert_eq!(pit2, other_pit2);
     }
 
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     #[test]
     fn test_clock() {
         let kvm = Kvm::new().unwrap();
@@ -2269,7 +2253,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     fn test_register_unregister_irqfd() {
         let kvm = Kvm::new().unwrap();
         let vm_fd = kvm.create_vm().unwrap();
@@ -2416,7 +2400,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     fn test_set_irq_line() {
         let kvm = Kvm::new().unwrap();
         let vm_fd = kvm.create_vm().unwrap();
@@ -2503,7 +2487,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     fn test_faulty_vm_fd() {
         let badf_errno = libc::EBADF;
 
@@ -2619,7 +2603,6 @@ mod tests {
     /// previously allocated from the guest itself.
     #[test]
     #[cfg(any(
-        target_arch = "x86",
         target_arch = "x86_64",
         target_arch = "arm",
         target_arch = "aarch64",
@@ -2644,7 +2627,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     fn test_enable_split_irqchip_cap() {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
@@ -2669,7 +2652,6 @@ mod tests {
 
     #[test]
     #[cfg(any(
-        target_arch = "x86",
         target_arch = "x86_64",
         target_arch = "arm",
         target_arch = "aarch64",
@@ -2681,9 +2663,9 @@ mod tests {
         let irq_routing = kvm_irq_routing::default();
 
         // Expect failure for x86 since the irqchip is not created yet.
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[cfg(target_arch = "x86_64")]
         vm.set_gsi_routing(&irq_routing).unwrap_err();
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[cfg(target_arch = "x86_64")]
         vm.create_irq_chip().unwrap();
 
         // RISC-V 64-bit expect an AIA device to be created in advance of
@@ -2719,7 +2701,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     #[cfg_attr(not(has_sev), ignore)]
     fn test_encrypt_op_sev() {
         let kvm = Kvm::new().unwrap();
@@ -2730,7 +2712,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     #[cfg_attr(not(has_sev), ignore)]
     fn test_register_unregister_enc_memory_region() {
         let sev = OpenOptions::new()

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -53,17 +53,11 @@ ioctl_iow_nr!(KVM_SET_IDENTITY_MAP_ADDR, KVMIO, 0x48, u64);
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 ioctl_iowr_nr!(KVM_CREATE_GUEST_MEMFD, KVMIO, 0xd4, kvm_create_guest_memfd);
 /* Available with KVM_CAP_IRQCHIP */
-#[cfg(any(
-    target_arch = "x86_64",
-    target_arch = "arm",
-    target_arch = "aarch64",
-    target_arch = "s390x"
-))]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "s390x"))]
 ioctl_io_nr!(KVM_CREATE_IRQCHIP, KVMIO, 0x60);
 /* Available with KVM_CAP_IRQCHIP */
 #[cfg(any(
     target_arch = "x86_64",
-    target_arch = "arm",
     target_arch = "aarch64",
     target_arch = "riscv64"
 ))]
@@ -85,7 +79,6 @@ ioctl_iow_nr!(
 /* Available with KVM_CAP_IRQ_ROUTING */
 #[cfg(any(
     target_arch = "x86_64",
-    target_arch = "arm",
     target_arch = "aarch64",
     target_arch = "riscv64"
 ))]
@@ -93,7 +86,6 @@ ioctl_iow_nr!(KVM_SET_GSI_ROUTING, KVMIO, 0x6a, kvm_irq_routing);
 /* Available with KVM_CAP_IRQFD */
 #[cfg(any(
     target_arch = "x86_64",
-    target_arch = "arm",
     target_arch = "aarch64",
     target_arch = "riscv64",
     target_arch = "s390x"
@@ -135,9 +127,9 @@ ioctl_ior_nr!(KVM_MEMORY_ENCRYPT_UNREG_REGION, KVMIO, 0xbc, kvm_enc_region);
 // Ioctls for VCPU fds.
 
 ioctl_io_nr!(KVM_RUN, KVMIO, 0x80);
-#[cfg(not(any(target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64")))]
+#[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
 ioctl_ior_nr!(KVM_GET_REGS, KVMIO, 0x81, kvm_regs);
-#[cfg(not(any(target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64")))]
+#[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
 ioctl_iow_nr!(KVM_SET_REGS, KVMIO, 0x82, kvm_regs);
 #[cfg(any(
     target_arch = "x86_64",
@@ -176,7 +168,6 @@ ioctl_iowr_nr!(KVM_GET_CPUID2, KVMIO, 0x91, kvm_cpuid2);
 /* Available with KVM_CAP_MP_STATE */
 #[cfg(any(
     target_arch = "x86_64",
-    target_arch = "arm",
     target_arch = "aarch64",
     target_arch = "riscv64",
     target_arch = "s390x"
@@ -185,7 +176,6 @@ ioctl_ior_nr!(KVM_GET_MP_STATE, KVMIO, 0x98, kvm_mp_state);
 /* Available with KVM_CAP_MP_STATE */
 #[cfg(any(
     target_arch = "x86_64",
-    target_arch = "arm",
     target_arch = "aarch64",
     target_arch = "riscv64",
     target_arch = "s390x"
@@ -195,10 +185,10 @@ ioctl_iow_nr!(KVM_SET_MP_STATE, KVMIO, 0x99, kvm_mp_state);
 #[cfg(target_arch = "x86_64")]
 ioctl_io_nr!(KVM_NMI, KVMIO, 0x9a);
 /* Available with KVM_CAP_VCPU_EVENTS */
-#[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 ioctl_ior_nr!(KVM_GET_VCPU_EVENTS, KVMIO, 0x9f, kvm_vcpu_events);
 /* Available with KVM_CAP_VCPU_EVENTS */
-#[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 ioctl_iow_nr!(KVM_SET_VCPU_EVENTS, KVMIO, 0xa0, kvm_vcpu_events);
 /* Available with KVM_CAP_DEBUGREGS */
 #[cfg(target_arch = "x86_64")]
@@ -230,26 +220,25 @@ ioctl_io_nr!(KVM_SET_TSC_KHZ, KVMIO, 0xa2);
 ioctl_io_nr!(KVM_GET_TSC_KHZ, KVMIO, 0xa3);
 
 /* Available with KVM_CAP_ENABLE_CAP */
-#[cfg(not(any(target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64")))]
+#[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
 ioctl_iow_nr!(KVM_ENABLE_CAP, KVMIO, 0xa3, kvm_enable_cap);
 /* Available with KVM_CAP_SIGNAL_MSI */
 #[cfg(any(
     target_arch = "x86_64",
-    target_arch = "arm",
     target_arch = "aarch64",
     target_arch = "riscv64"
 ))]
 ioctl_iow_nr!(KVM_SIGNAL_MSI, KVMIO, 0xa5, kvm_msi);
 /* Available with KVM_CAP_ONE_REG */
-#[cfg(any(target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64"))]
+#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 ioctl_iow_nr!(KVM_GET_ONE_REG, KVMIO, 0xab, kvm_one_reg);
-#[cfg(any(target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64"))]
+#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 ioctl_iow_nr!(KVM_SET_ONE_REG, KVMIO, 0xac, kvm_one_reg);
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 ioctl_iow_nr!(KVM_ARM_VCPU_INIT, KVMIO, 0xae, kvm_vcpu_init);
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 ioctl_ior_nr!(KVM_ARM_PREFERRED_TARGET, KVMIO, 0xaf, kvm_vcpu_init);
-#[cfg(any(target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64"))]
+#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 ioctl_iowr_nr!(KVM_GET_REG_LIST, KVMIO, 0xb0, kvm_reg_list);
 
 /* Available with KVM_CAP_X86_SMM */

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -13,18 +13,18 @@ use kvm_bindings::*;
 
 ioctl_io_nr!(KVM_GET_API_VERSION, KVMIO, 0x00);
 ioctl_io_nr!(KVM_CREATE_VM, KVMIO, 0x01);
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iowr_nr!(KVM_GET_MSR_INDEX_LIST, KVMIO, 0x02, kvm_msr_list);
 ioctl_io_nr!(KVM_CHECK_EXTENSION, KVMIO, 0x03);
 ioctl_io_nr!(KVM_GET_VCPU_MMAP_SIZE, KVMIO, 0x04);
 /* Available with KVM_CAP_EXT_CPUID */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iowr_nr!(KVM_GET_SUPPORTED_CPUID, KVMIO, 0x05, kvm_cpuid2);
 /* Available with KVM_CAP_EXT_EMUL_CPUID */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iowr_nr!(KVM_GET_EMULATED_CPUID, KVMIO, 0x09, kvm_cpuid2);
 /* Available with KVM_CAP_GET_MSR_FEATURES */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iowr_nr!(KVM_GET_MSR_FEATURE_INDEX_LIST, KVMIO, 0x0a, kvm_msr_list);
 
 // Ioctls for VM fds.
@@ -45,16 +45,15 @@ ioctl_iow_nr!(
     kvm_userspace_memory_region2
 );
 /* Available with KVM_CAP_SET_TSS_ADDR */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_io_nr!(KVM_SET_TSS_ADDR, KVMIO, 0x47);
 /* Available with KVM_CAP_SET_IDENTITY_MAP_ADDR */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iow_nr!(KVM_SET_IDENTITY_MAP_ADDR, KVMIO, 0x48, u64);
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 ioctl_iowr_nr!(KVM_CREATE_GUEST_MEMFD, KVMIO, 0xd4, kvm_create_guest_memfd);
 /* Available with KVM_CAP_IRQCHIP */
 #[cfg(any(
-    target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "arm",
     target_arch = "aarch64",
@@ -63,7 +62,6 @@ ioctl_iowr_nr!(KVM_CREATE_GUEST_MEMFD, KVMIO, 0xd4, kvm_create_guest_memfd);
 ioctl_io_nr!(KVM_CREATE_IRQCHIP, KVMIO, 0x60);
 /* Available with KVM_CAP_IRQCHIP */
 #[cfg(any(
-    target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "arm",
     target_arch = "aarch64",
@@ -86,7 +84,6 @@ ioctl_iow_nr!(
 );
 /* Available with KVM_CAP_IRQ_ROUTING */
 #[cfg(any(
-    target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "arm",
     target_arch = "aarch64",
@@ -95,7 +92,6 @@ ioctl_iow_nr!(
 ioctl_iow_nr!(KVM_SET_GSI_ROUTING, KVMIO, 0x6a, kvm_irq_routing);
 /* Available with KVM_CAP_IRQFD */
 #[cfg(any(
-    target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "arm",
     target_arch = "aarch64",
@@ -104,36 +100,36 @@ ioctl_iow_nr!(KVM_SET_GSI_ROUTING, KVMIO, 0x6a, kvm_irq_routing);
 ))]
 ioctl_iow_nr!(KVM_IRQFD, KVMIO, 0x76, kvm_irqfd);
 /* Available with KVM_CAP_PIT2 */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iow_nr!(KVM_CREATE_PIT2, KVMIO, 0x77, kvm_pit_config);
 /* Available with KVM_CAP_IOEVENTFD */
 ioctl_iow_nr!(KVM_IOEVENTFD, KVMIO, 0x79, kvm_ioeventfd);
 /* Available with KVM_CAP_IRQCHIP */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iowr_nr!(KVM_GET_IRQCHIP, KVMIO, 0x62, kvm_irqchip);
 /* Available with KVM_CAP_IRQCHIP */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_ior_nr!(KVM_SET_IRQCHIP, KVMIO, 0x63, kvm_irqchip);
 /* Available with KVM_CAP_ADJUST_CLOCK */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iow_nr!(KVM_SET_CLOCK, KVMIO, 0x7b, kvm_clock_data);
 /* Available with KVM_CAP_ADJUST_CLOCK */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_ior_nr!(KVM_GET_CLOCK, KVMIO, 0x7c, kvm_clock_data);
 /* Available with KVM_CAP_PIT_STATE2 */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_ior_nr!(KVM_GET_PIT2, KVMIO, 0x9f, kvm_pit_state2);
 /* Available with KVM_CAP_PIT_STATE2 */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iow_nr!(KVM_SET_PIT2, KVMIO, 0xa0, kvm_pit_state2);
 /* KVM_MEMORY_ENCRYPT_OP. Takes opaque platform dependent type: i.e. TDX or SEV */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iowr_nr!(KVM_MEMORY_ENCRYPT_OP, KVMIO, 0xba, std::os::raw::c_ulong);
 /* Available on SEV-enabled guests. */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_ior_nr!(KVM_MEMORY_ENCRYPT_REG_REGION, KVMIO, 0xbb, kvm_enc_region);
 /* Available on SEV-enabled guests. */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_ior_nr!(KVM_MEMORY_ENCRYPT_UNREG_REGION, KVMIO, 0xbc, kvm_enc_region);
 
 // Ioctls for VCPU fds.
@@ -144,44 +140,41 @@ ioctl_ior_nr!(KVM_GET_REGS, KVMIO, 0x81, kvm_regs);
 #[cfg(not(any(target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64")))]
 ioctl_iow_nr!(KVM_SET_REGS, KVMIO, 0x82, kvm_regs);
 #[cfg(any(
-    target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "powerpc",
     target_arch = "powerpc64"
 ))]
 ioctl_ior_nr!(KVM_GET_SREGS, KVMIO, 0x83, kvm_sregs);
 #[cfg(any(
-    target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "powerpc",
     target_arch = "powerpc64"
 ))]
 ioctl_iow_nr!(KVM_SET_SREGS, KVMIO, 0x84, kvm_sregs);
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iowr_nr!(KVM_TRANSLATE, KVMIO, 0x85, kvm_translation);
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iowr_nr!(KVM_GET_MSRS, KVMIO, 0x88, kvm_msrs);
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iow_nr!(KVM_SET_MSRS, KVMIO, 0x89, kvm_msrs);
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_ior_nr!(KVM_GET_FPU, KVMIO, 0x8c, kvm_fpu);
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iow_nr!(KVM_SET_FPU, KVMIO, 0x8d, kvm_fpu);
 /* Available with KVM_CAP_IRQCHIP */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_ior_nr!(KVM_GET_LAPIC, KVMIO, 0x8e, kvm_lapic_state);
 /* Available with KVM_CAP_IRQCHIP */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iow_nr!(KVM_SET_LAPIC, KVMIO, 0x8f, kvm_lapic_state);
 /* Available with KVM_CAP_EXT_CPUID */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iow_nr!(KVM_SET_CPUID2, KVMIO, 0x90, kvm_cpuid2);
 /* Available with KVM_CAP_EXT_CPUID */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iowr_nr!(KVM_GET_CPUID2, KVMIO, 0x91, kvm_cpuid2);
 /* Available with KVM_CAP_MP_STATE */
 #[cfg(any(
-    target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "arm",
     target_arch = "aarch64",
@@ -191,7 +184,6 @@ ioctl_iowr_nr!(KVM_GET_CPUID2, KVMIO, 0x91, kvm_cpuid2);
 ioctl_ior_nr!(KVM_GET_MP_STATE, KVMIO, 0x98, kvm_mp_state);
 /* Available with KVM_CAP_MP_STATE */
 #[cfg(any(
-    target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "arm",
     target_arch = "aarch64",
@@ -200,51 +192,41 @@ ioctl_ior_nr!(KVM_GET_MP_STATE, KVMIO, 0x98, kvm_mp_state);
 ))]
 ioctl_iow_nr!(KVM_SET_MP_STATE, KVMIO, 0x99, kvm_mp_state);
 /* Available with KVM_CAP_USER_NMI */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_io_nr!(KVM_NMI, KVMIO, 0x9a);
 /* Available with KVM_CAP_VCPU_EVENTS */
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    target_arch = "arm",
-    target_arch = "aarch64"
-))]
+#[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
 ioctl_ior_nr!(KVM_GET_VCPU_EVENTS, KVMIO, 0x9f, kvm_vcpu_events);
 /* Available with KVM_CAP_VCPU_EVENTS */
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    target_arch = "arm",
-    target_arch = "aarch64"
-))]
+#[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
 ioctl_iow_nr!(KVM_SET_VCPU_EVENTS, KVMIO, 0xa0, kvm_vcpu_events);
 /* Available with KVM_CAP_DEBUGREGS */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_ior_nr!(KVM_GET_DEBUGREGS, KVMIO, 0xa1, kvm_debugregs);
 /* Available with KVM_CAP_DEBUGREGS */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iow_nr!(KVM_SET_DEBUGREGS, KVMIO, 0xa2, kvm_debugregs);
 /* Available with KVM_CAP_XSAVE */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_ior_nr!(KVM_GET_XSAVE, KVMIO, 0xa4, kvm_xsave);
 /* Available with KVM_CAP_XSAVE */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iow_nr!(KVM_SET_XSAVE, KVMIO, 0xa5, kvm_xsave);
 /* Available with KVM_CAP_XCRS */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_ior_nr!(KVM_GET_XCRS, KVMIO, 0xa6, kvm_xcrs);
 /* Available with KVM_CAP_XCRS */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_iow_nr!(KVM_SET_XCRS, KVMIO, 0xa7, kvm_xcrs);
 /* Available with KVM_CAP_KVMCLOCK_CTRL */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_io_nr!(KVM_KVMCLOCK_CTRL, KVMIO, 0xad);
 
 /* Available with KVM_CAP_TSC_CONTROL */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_io_nr!(KVM_SET_TSC_KHZ, KVMIO, 0xa2);
 /* Available with KVM_CAP_GET_TSC_KHZ */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_io_nr!(KVM_GET_TSC_KHZ, KVMIO, 0xa3);
 
 /* Available with KVM_CAP_ENABLE_CAP */
@@ -252,7 +234,6 @@ ioctl_io_nr!(KVM_GET_TSC_KHZ, KVMIO, 0xa3);
 ioctl_iow_nr!(KVM_ENABLE_CAP, KVMIO, 0xa3, kvm_enable_cap);
 /* Available with KVM_CAP_SIGNAL_MSI */
 #[cfg(any(
-    target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "arm",
     target_arch = "aarch64",
@@ -272,7 +253,7 @@ ioctl_ior_nr!(KVM_ARM_PREFERRED_TARGET, KVMIO, 0xaf, kvm_vcpu_init);
 ioctl_iowr_nr!(KVM_GET_REG_LIST, KVMIO, 0xb0, kvm_reg_list);
 
 /* Available with KVM_CAP_X86_SMM */
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 ioctl_io_nr!(KVM_SMI, KVMIO, 0xb7);
 
 /* Available with KVM_CAP_ARM_SVE */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@
 //!     let asm_code: &[u8];
 //!
 //!     // Setting up architectural dependent values.
-//!     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+//!     #[cfg(target_arch = "x86_64")]
 //!     {
 //!         asm_code = &[
 //!             0xba, 0xf8, 0x03, /* mov $0x3f8, %dx */
@@ -147,7 +147,7 @@
 //!     let mut vcpu_fd = vm.create_vcpu(0).unwrap();
 //!
 //!     // 5. Initialize general purpose and special registers.
-//!     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+//!     #[cfg(target_arch = "x86_64")]
 //!     {
 //!         // x86_64 specific registry setup.
 //!         let mut vcpu_sregs = vcpu_fd.get_sregs().unwrap();
@@ -248,7 +248,7 @@ pub use ioctls::system::Kvm;
 pub use ioctls::vcpu::reg_size;
 pub use ioctls::vcpu::{HypercallExit, VcpuExit, VcpuFd};
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 pub use ioctls::vcpu::{MsrExitReason, ReadMsrExit, SyncReg, WriteMsrExit};
 
 pub use ioctls::vm::{IoEventAddress, NoDatamatch, VmFd};
@@ -257,7 +257,7 @@ pub use ioctls::vm::{IoEventAddress, NoDatamatch, VmFd};
 /// # Example
 ///
 /// ```
-/// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+/// #[cfg(target_arch = "x86_64")]
 /// use kvm_ioctls::{Error, KvmRunWrapper};
 /// ```
 pub use ioctls::KvmRunWrapper;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,7 @@ mod ioctls;
 pub use cap::Cap;
 pub use ioctls::device::DeviceFd;
 pub use ioctls::system::Kvm;
-#[cfg(any(target_arch = "arm", target_arch = "aarch64", target_arch = "riscv64"))]
+#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 pub use ioctls::vcpu::reg_size;
 pub use ioctls::vcpu::{HypercallExit, VcpuExit, VcpuFd};
 


### PR DESCRIPTION
### Summary of the PR

- The x86 32-bit is not supported in other
rust-vmm crates, dropping the `target_arch = "x86"` predicates to stop
supporting x86 32-bit.
- KVM on ARM32 hosts were dropped since v5.7 [1],
dropping `target_arch = "arm"` predicates to stop supporting ARM 32-bit
architecture.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
