### PR TITLE
chore: Prepare 0.19.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 ## Upcoming Release
 
+## v0.19.0
+
 ### Added
 
-- [[#289](https://github.com/rust-vmm/kvm-ioctls/pull/289)]: Drop `x86` and `arm` support.
 - [[#275](https://github.com/rust-vmm/kvm-ioctls/pull/275)]: Introduce `riscv64` ioctls.
+
+### Removed
+
+- [[#289](https://github.com/rust-vmm/kvm-ioctls/pull/289)]: Drop `x86` 32-bit
+  and `arm` 32-bit support.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvm-ioctls"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Amazon Firecracker Team <firecracker-maintainers@amazon.com>"]
 description = "Safe wrappers over KVM ioctls"
 repository = "https://github.com/rust-vmm/kvm-ioctls"

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -1203,7 +1203,7 @@ impl VcpuFd {
     /// // KVM_GET_REG_LIST on Aarch64 demands that the vcpus be initialized.
     /// #[cfg(target_arch = "aarch64")]
     /// {
-    ///     let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
+    ///     let mut kvi = kvm_bindings::kvm_vcpu_init::default();
     ///     vm.get_preferred_target(&mut kvi).unwrap();
     ///     vcpu.vcpu_init(&kvi).expect("Cannot initialize vcpu");
     ///
@@ -2321,7 +2321,7 @@ mod tests {
         }
 
         let mut vcpu_fd = vm.create_vcpu(0).unwrap();
-        let mut kvi = kvm_bindings::kvm_vcpu_init::default();
+        let mut kvi = kvm_vcpu_init::default();
         vm.get_preferred_target(&mut kvi).unwrap();
         kvi.features[0] |= 1 << KVM_ARM_VCPU_PSCI_0_2;
         vcpu_fd.vcpu_init(&kvi).unwrap();
@@ -2784,7 +2784,7 @@ mod tests {
 
         // KVM defines valid targets as 0 to KVM_ARM_NUM_TARGETS-1, so pick a big raw number
         // greater than that as target to be invalid
-        let kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init {
+        let kvi = kvm_vcpu_init {
             target: 300,
             ..Default::default()
         };
@@ -2808,7 +2808,7 @@ mod tests {
             coalesced_mmio_ring: None,
         };
 
-        let device_attr = kvm_bindings::kvm_device_attr {
+        let device_attr = kvm_device_attr {
             group: KVM_ARM_VCPU_PMU_V3_CTRL,
             attr: u64::from(KVM_ARM_VCPU_PMU_V3_INIT),
             addr: 0x0,
@@ -2926,7 +2926,7 @@ mod tests {
         let vm = kvm.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
 
-        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
+        let mut kvi = kvm_vcpu_init::default();
 
         vm.get_preferred_target(&mut kvi)
             .expect("Cannot get preferred target");
@@ -2940,7 +2940,7 @@ mod tests {
         let vm = kvm.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
 
-        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
+        let mut kvi = kvm_vcpu_init::default();
         vm.get_preferred_target(&mut kvi)
             .expect("Cannot get preferred target");
         vcpu.vcpu_init(&kvi).expect("Cannot initialize vcpu");
@@ -2966,7 +2966,7 @@ mod tests {
         let vm = kvm.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
 
-        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
+        let mut kvi = kvm_vcpu_init::default();
         vm.get_preferred_target(&mut kvi)
             .expect("Cannot get preferred target");
         vcpu.vcpu_init(&kvi).expect("Cannot initialize vcpu");
@@ -3007,7 +3007,7 @@ mod tests {
         let err = vcpu.get_reg_list(&mut reg_list).unwrap_err();
         assert!(err.errno() == libc::ENOEXEC);
 
-        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
+        let mut kvi = kvm_vcpu_init::default();
         vm.get_preferred_target(&mut kvi)
             .expect("Cannot get preferred target");
         vcpu.vcpu_init(&kvi).expect("Cannot initialize vcpu");
@@ -3321,7 +3321,7 @@ mod tests {
         let vm = kvm.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
 
-        let dist_attr = kvm_bindings::kvm_device_attr {
+        let dist_attr = kvm_device_attr {
             group: KVM_ARM_VCPU_PMU_V3_CTRL,
             attr: u64::from(KVM_ARM_VCPU_PMU_V3_INIT),
             addr: 0x0,
@@ -3330,10 +3330,10 @@ mod tests {
 
         vcpu.has_device_attr(&dist_attr).unwrap_err();
         vcpu.set_device_attr(&dist_attr).unwrap_err();
-        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
+        let mut kvi: kvm_vcpu_init = kvm_vcpu_init::default();
         vm.get_preferred_target(&mut kvi)
             .expect("Cannot get preferred target");
-        kvi.features[0] |= 1 << kvm_bindings::KVM_ARM_VCPU_PSCI_0_2 | 1 << KVM_ARM_VCPU_PMU_V3;
+        kvi.features[0] |= 1 << KVM_ARM_VCPU_PSCI_0_2 | 1 << KVM_ARM_VCPU_PMU_V3;
         vcpu.vcpu_init(&kvi).unwrap();
         vcpu.has_device_attr(&dist_attr).unwrap();
         vcpu.set_device_attr(&dist_attr).unwrap();
@@ -3346,14 +3346,14 @@ mod tests {
         let vm = kvm.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
 
-        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
+        let mut kvi = kvm_vcpu_init::default();
         vm.get_preferred_target(&mut kvi)
             .expect("Cannot get preferred target");
         if kvm.check_extension(Cap::ArmPtrAuthAddress) {
-            kvi.features[0] |= 1 << kvm_bindings::KVM_ARM_VCPU_PTRAUTH_ADDRESS;
+            kvi.features[0] |= 1 << KVM_ARM_VCPU_PTRAUTH_ADDRESS;
         }
         if kvm.check_extension(Cap::ArmPtrAuthGeneric) {
-            kvi.features[0] |= 1 << kvm_bindings::KVM_ARM_VCPU_PTRAUTH_GENERIC;
+            kvi.features[0] |= 1 << KVM_ARM_VCPU_PTRAUTH_GENERIC;
         }
         vcpu.vcpu_init(&kvi).unwrap();
     }

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -1916,7 +1916,7 @@ impl AsRawFd for VmFd {
 #[cfg(test)]
 #[cfg(target_arch = "aarch64")]
 pub(crate) fn create_gic_device(vm: &VmFd, flags: u32) -> DeviceFd {
-    let mut gic_device = kvm_bindings::kvm_create_device {
+    let mut gic_device = kvm_create_device {
         type_: kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3,
         fd: 0,
         flags,
@@ -1940,8 +1940,8 @@ pub(crate) fn create_gic_device(vm: &VmFd, flags: u32) -> DeviceFd {
 #[cfg(test)]
 #[cfg(target_arch = "aarch64")]
 pub(crate) fn set_supported_nr_irqs(vgic: &DeviceFd, nr_irqs: u32) {
-    let vgic_attr = kvm_bindings::kvm_device_attr {
-        group: kvm_bindings::KVM_DEV_ARM_VGIC_GRP_NR_IRQS,
+    let vgic_attr = kvm_device_attr {
+        group: KVM_DEV_ARM_VGIC_GRP_NR_IRQS,
         attr: 0,
         addr: &nr_irqs as *const u32 as u64,
         flags: 0,
@@ -1958,9 +1958,9 @@ pub(crate) fn set_supported_nr_irqs(vgic: &DeviceFd, nr_irqs: u32) {
 #[cfg(test)]
 #[cfg(target_arch = "aarch64")]
 pub(crate) fn request_gic_init(vgic: &DeviceFd) {
-    let vgic_attr = kvm_bindings::kvm_device_attr {
-        group: kvm_bindings::KVM_DEV_ARM_VGIC_GRP_CTRL,
-        attr: u64::from(kvm_bindings::KVM_DEV_ARM_VGIC_CTRL_INIT),
+    let vgic_attr = kvm_device_attr {
+        group: KVM_DEV_ARM_VGIC_GRP_CTRL,
+        attr: u64::from(KVM_DEV_ARM_VGIC_CTRL_INIT),
         addr: 0,
         flags: 0,
     };
@@ -1977,7 +1977,7 @@ pub(crate) fn request_gic_init(vgic: &DeviceFd) {
 #[cfg(test)]
 #[cfg(target_arch = "riscv64")]
 pub(crate) fn create_aia_device(vm: &VmFd, flags: u32) -> DeviceFd {
-    let mut aia_device = kvm_bindings::kvm_create_device {
+    let mut aia_device = kvm_create_device {
         type_: kvm_device_type_KVM_DEV_TYPE_RISCV_AIA,
         fd: 0,
         flags,
@@ -1995,9 +1995,9 @@ pub(crate) fn create_aia_device(vm: &VmFd, flags: u32) -> DeviceFd {
 #[cfg(test)]
 #[cfg(target_arch = "riscv64")]
 pub(crate) fn set_supported_nr_irqs(vaia: &DeviceFd, nr_irqs: u32) {
-    let vaia_attr = kvm_bindings::kvm_device_attr {
-        group: kvm_bindings::KVM_DEV_RISCV_AIA_GRP_CONFIG,
-        attr: u64::from(kvm_bindings::KVM_DEV_RISCV_AIA_CONFIG_SRCS),
+    let vaia_attr = kvm_device_attr {
+        group: KVM_DEV_RISCV_AIA_GRP_CONFIG,
+        attr: u64::from(KVM_DEV_RISCV_AIA_CONFIG_SRCS),
         addr: &nr_irqs as *const u32 as u64,
         flags: 0,
     };
@@ -2013,9 +2013,9 @@ pub(crate) fn set_supported_nr_irqs(vaia: &DeviceFd, nr_irqs: u32) {
 #[cfg(test)]
 #[cfg(target_arch = "riscv64")]
 pub(crate) fn request_aia_init(vaia: &DeviceFd) {
-    let vaia_attr = kvm_bindings::kvm_device_attr {
-        group: kvm_bindings::KVM_DEV_RISCV_AIA_GRP_CTRL,
-        attr: u64::from(kvm_bindings::KVM_DEV_RISCV_AIA_CTRL_INIT),
+    let vaia_attr = kvm_device_attr {
+        group: KVM_DEV_RISCV_AIA_GRP_CTRL,
+        attr: u64::from(KVM_DEV_RISCV_AIA_CTRL_INIT),
         addr: 0,
         flags: 0,
     };
@@ -2129,7 +2129,7 @@ mod tests {
 
         // On ARM/arm64, a GICv2 is created. It's better to check ahead whether GICv2
         // can be emulated or not.
-        let mut gic_device = kvm_bindings::kvm_create_device {
+        let mut gic_device = kvm_create_device {
             type_: kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2,
             fd: 0,
             flags: KVM_CREATE_DEVICE_TEST,
@@ -2588,7 +2588,7 @@ mod tests {
     fn test_get_preferred_target() {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
-        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
+        let mut kvi = kvm_vcpu_init::default();
         vm.get_preferred_target(&mut kvi).unwrap();
     }
 


### PR DESCRIPTION
### Summary of the PR

Update kvm-ioctls from v0.18.0 to v0.19.0 to incorporate RISC-V support.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
