### PR TITLE
Cleanup usage of cfg(target_arch = "...") in doc tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Upcoming Release
 
+### Added 
+
+- [[#288](https://github.com/rust-vmm/kvm-ioctls/pull/288)]: Introduce `Cap::GuestMemfd`, `Cap::MemoryAttributes` and 
+   `Cap::UserMemory2` capabilities enum variants for use with `VmFd::check_extension`.
+
 ## v0.19.0
 
 ### Added

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -160,4 +160,7 @@ pub enum Cap {
     ExitHypercall = KVM_CAP_EXIT_HYPERCALL,
     #[cfg(target_arch = "x86_64")]
     MemoryFaultInfo = KVM_CAP_MEMORY_FAULT_INFO,
+    UserMemory2 = KVM_CAP_USER_MEMORY2,
+    GuestMemfd = KVM_CAP_GUEST_MEMFD,
+    MemoryAttributes = KVM_CAP_MEMORY_ATTRIBUTES,
 }

--- a/src/ioctls/device.rs
+++ b/src/ioctls/device.rs
@@ -57,33 +57,33 @@ impl DeviceFd {
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     ///
-    /// #[cfg(not(target_arch = "riscv64"))]
-    /// {
-    ///     # use kvm_bindings::{
-    ///     #     kvm_device_type_KVM_DEV_TYPE_VFIO,
-    ///     #     KVM_DEV_VFIO_GROUP, KVM_DEV_VFIO_GROUP_ADD, KVM_CREATE_DEVICE_TEST
-    ///     # };
-    ///     let mut device = kvm_bindings::kvm_create_device {
-    ///         type_: kvm_device_type_KVM_DEV_TYPE_VFIO,
-    ///         fd: 0,
-    ///         flags: KVM_CREATE_DEVICE_TEST,
-    ///     };
+    /// # #[cfg(not(target_arch = "riscv64"))]
+    /// # {
+    /// # use kvm_bindings::{
+    /// #     kvm_device_type_KVM_DEV_TYPE_VFIO,
+    /// #     KVM_DEV_VFIO_GROUP, KVM_DEV_VFIO_GROUP_ADD, KVM_CREATE_DEVICE_TEST
+    /// # };
+    /// let mut device = kvm_bindings::kvm_create_device {
+    ///     type_: kvm_device_type_KVM_DEV_TYPE_VFIO,
+    ///     fd: 0,
+    ///     flags: KVM_CREATE_DEVICE_TEST,
+    /// };
     ///
-    ///     let device_fd = vm
-    ///         .create_device(&mut device)
-    ///         .expect("Cannot create KVM device");
+    /// let device_fd = vm
+    ///     .create_device(&mut device)
+    ///     .expect("Cannot create KVM device");
     ///
-    ///     let dist_attr = kvm_bindings::kvm_device_attr {
-    ///         group: KVM_DEV_VFIO_GROUP,
-    ///         attr: u64::from(KVM_DEV_VFIO_GROUP_ADD),
-    ///         addr: 0x0,
-    ///         flags: 0,
-    ///     };
+    /// let dist_attr = kvm_bindings::kvm_device_attr {
+    ///     group: KVM_DEV_VFIO_GROUP,
+    ///     attr: u64::from(KVM_DEV_VFIO_GROUP_ADD),
+    ///     addr: 0x0,
+    ///     flags: 0,
+    /// };
     ///
-    ///     if (device_fd.has_device_attr(&dist_attr).is_ok()) {
-    ///         device_fd.set_device_attr(&dist_attr).unwrap();
-    ///     }
+    /// if (device_fd.has_device_attr(&dist_attr).is_ok()) {
+    ///     device_fd.set_device_attr(&dist_attr).unwrap();
     /// }
+    /// # }
     /// ```
     pub fn set_device_attr(&self, device_attr: &kvm_device_attr) -> Result<()> {
         // SAFETY: We are calling this function with a Device fd, and we trust the kernel.
@@ -120,46 +120,46 @@ impl DeviceFd {
     /// including that it is safe to write to the `addr` member.
     ///
     /// # Examples
+    ///
+    /// Getting the number of IRQs for a GICv2 device on an aarch64 platform
+    ///
     /// ```rust
     /// # extern crate kvm_ioctls;
     /// # extern crate kvm_bindings;
     /// # use kvm_ioctls::Kvm;
-    ///
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     ///
-    /// // As on x86_64, `get_device_attr` is not necessarily needed. Therefore here
-    /// // the code example is only for AArch64.
-    /// #[cfg(any(target_arch = "aarch64"))]
-    /// {
-    ///     use kvm_bindings::{
-    ///         kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2, kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3,
-    ///         KVM_DEV_ARM_VGIC_GRP_NR_IRQS,
-    ///     };
+    /// # #[cfg(target_arch = "aarch64")]
+    /// # {
+    /// use kvm_bindings::{
+    ///     kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2, kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3,
+    ///     KVM_DEV_ARM_VGIC_GRP_NR_IRQS,
+    /// };
     ///
-    ///     // Create a GIC device.
-    ///     let mut gic_device = kvm_bindings::kvm_create_device {
-    ///         type_: kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3,
-    ///         fd: 0,
-    ///         flags: 0,
-    ///     };
-    ///     let device_fd = match vm.create_device(&mut gic_device) {
-    ///         Ok(fd) => fd,
-    ///         Err(_) => {
-    ///             gic_device.type_ = kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2;
-    ///             vm.create_device(&mut gic_device)
-    ///                 .expect("Cannot create KVM vGIC device")
-    ///         }
-    ///     };
+    /// // Create a GIC device.
+    /// let mut gic_device = kvm_bindings::kvm_create_device {
+    ///     type_: kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3,
+    ///     fd: 0,
+    ///     flags: 0,
+    /// };
+    /// let device_fd = match vm.create_device(&mut gic_device) {
+    ///     Ok(fd) => fd,
+    ///     Err(_) => {
+    ///         gic_device.type_ = kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2;
+    ///         vm.create_device(&mut gic_device)
+    ///             .expect("Cannot create KVM vGIC device")
+    ///     }
+    /// };
     ///
-    ///     let mut data: u32 = 0;
-    ///     let mut gic_attr = kvm_bindings::kvm_device_attr::default();
-    ///     gic_attr.group = KVM_DEV_ARM_VGIC_GRP_NR_IRQS;
-    ///     gic_attr.addr = &mut data as *mut u32 as u64;
+    /// let mut data: u32 = 0;
+    /// let mut gic_attr = kvm_bindings::kvm_device_attr::default();
+    /// gic_attr.group = KVM_DEV_ARM_VGIC_GRP_NR_IRQS;
+    /// gic_attr.addr = &mut data as *mut u32 as u64;
     ///
-    ///     // SAFETY: gic_attr.addr is safe to write to.
-    ///     unsafe { device_fd.get_device_attr(&mut gic_attr) }.unwrap();
-    /// }
+    /// // SAFETY: gic_attr.addr is safe to write to.
+    /// unsafe { device_fd.get_device_attr(&mut gic_attr) }.unwrap();
+    /// # }
     /// ```
     pub unsafe fn get_device_attr(&self, device_attr: &mut kvm_device_attr) -> Result<()> {
         // SAFETY: Caller has ensured device_attr.addr is safe to write to.

--- a/src/ioctls/system.rs
+++ b/src/ioctls/system.rs
@@ -556,7 +556,7 @@ impl Kvm {
     /// // Check that the VM mmap size is the same reported by `KVM_GET_VCPU_MMAP_SIZE`.
     /// assert!(vm.run_size() == kvm.get_vcpu_mmap_size().unwrap());
     /// ```
-    #[cfg(not(any(target_arch = "aarch64")))]
+    #[cfg(not(target_arch = "aarch64"))]
     pub fn create_vm(&self) -> Result<VmFd> {
         self.create_vm_with_type(0) // Create using default VM type
     }
@@ -574,7 +574,7 @@ impl Kvm {
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     /// // Check that the VM mmap size is the same reported by `KVM_GET_VCPU_MMAP_SIZE`.
-    /// assert!(vm.run_size() == kvm.get_vcpu_mmap_size().unwrap());
+    /// assert_eq!(vm.run_size(), kvm.get_vcpu_mmap_size().unwrap());
     /// ```
     #[cfg(target_arch = "aarch64")]
     pub fn create_vm(&self) -> Result<VmFd> {
@@ -612,7 +612,7 @@ impl Kvm {
     ///     let host_ipa_limit = kvm.get_host_ipa_limit();
     ///     let vm = kvm.create_vm_with_ipa_size(host_ipa_limit as u32).unwrap();
     ///     // Check that the VM mmap size is the same reported by `KVM_GET_VCPU_MMAP_SIZE`.
-    ///     assert!(vm.run_size() == kvm.get_vcpu_mmap_size().unwrap());
+    ///     assert_eq!(vm.run_size(), kvm.get_vcpu_mmap_size().unwrap());
     /// }
     /// ```
     #[cfg(target_arch = "aarch64")]
@@ -635,7 +635,7 @@ impl Kvm {
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm_with_type(0).unwrap();
     /// // Check that the VM mmap size is the same reported by `KVM_GET_VCPU_MMAP_SIZE`.
-    /// assert!(vm.run_size() == kvm.get_vcpu_mmap_size().unwrap());
+    /// assert_eq!(vm.run_size(), kvm.get_vcpu_mmap_size().unwrap());
     /// ```
     pub fn create_vm_with_type(&self, vm_type: u64) -> Result<VmFd> {
         // SAFETY: Safe because we know `self.kvm` is a real KVM fd as this module is the only one

--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -426,7 +426,6 @@ impl VcpuFd {
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     /// let vcpu = vm.create_vcpu(0).unwrap();
-    /// #[cfg(target_arch = "x86_64")]
     /// let fpu = vcpu.get_fpu().unwrap();
     /// ```
     #[cfg(target_arch = "x86_64")]
@@ -457,15 +456,13 @@ impl VcpuFd {
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     /// let vcpu = vm.create_vcpu(0).unwrap();
-    /// #[cfg(target_arch = "x86_64")]
-    /// {
-    ///     let KVM_FPU_CWD: u16 = 0x37f;
-    ///     let fpu = kvm_fpu {
-    ///         fcw: KVM_FPU_CWD,
-    ///         ..Default::default()
-    ///     };
-    ///     vcpu.set_fpu(&fpu).unwrap();
-    /// }
+    ///
+    /// let KVM_FPU_CWD: u16 = 0x37f;
+    /// let fpu = kvm_fpu {
+    ///     fcw: KVM_FPU_CWD,
+    ///     ..Default::default()
+    /// };
+    /// vcpu.set_fpu(&fpu).unwrap();
     /// ```
     #[cfg(target_arch = "x86_64")]
     pub fn set_fpu(&self, fpu: &kvm_fpu) -> Result<()> {
@@ -499,13 +496,11 @@ impl VcpuFd {
     ///
     /// // Update the CPUID entries to disable the EPB feature.
     /// const ECX_EPB_SHIFT: u32 = 3;
-    /// {
-    ///     let entries = kvm_cpuid.as_mut_slice();
-    ///     for entry in entries.iter_mut() {
-    ///         match entry.function {
-    ///             6 => entry.ecx &= !(1 << ECX_EPB_SHIFT),
-    ///             _ => (),
-    ///         }
+    /// let entries = kvm_cpuid.as_mut_slice();
+    /// for entry in entries.iter_mut() {
+    ///     match entry.function {
+    ///         6 => entry.ecx &= !(1 << ECX_EPB_SHIFT),
+    ///         _ => (),
     ///     }
     /// }
     ///
@@ -581,18 +576,16 @@ impl VcpuFd {
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
     /// let mut cap: kvm_enable_cap = Default::default();
-    /// if cfg!(target_arch = "x86_64") {
-    ///     // KVM_CAP_HYPERV_SYNIC needs KVM_CAP_SPLIT_IRQCHIP enabled
-    ///     cap.cap = KVM_CAP_SPLIT_IRQCHIP;
-    ///     cap.args[0] = 24;
-    ///     vm.enable_cap(&cap).unwrap();
+    /// // KVM_CAP_HYPERV_SYNIC needs KVM_CAP_SPLIT_IRQCHIP enabled
+    /// cap.cap = KVM_CAP_SPLIT_IRQCHIP;
+    /// cap.args[0] = 24;
+    /// vm.enable_cap(&cap).unwrap();
     ///
-    ///     let vcpu = vm.create_vcpu(0).unwrap();
-    ///     if kvm.check_extension(Cap::HypervSynic) {
-    ///         let mut cap: kvm_enable_cap = Default::default();
-    ///         cap.cap = KVM_CAP_HYPERV_SYNIC;
-    ///         vcpu.enable_cap(&cap).unwrap();
-    ///     }
+    /// let vcpu = vm.create_vcpu(0).unwrap();
+    /// if kvm.check_extension(Cap::HypervSynic) {
+    ///     let mut cap: kvm_enable_cap = Default::default();
+    ///     cap.cap = KVM_CAP_HYPERV_SYNIC;
+    ///     vcpu.enable_cap(&cap).unwrap();
     /// }
     /// ```
     ///
@@ -1246,19 +1239,16 @@ impl VcpuFd {
     /// let vm = kvm.create_vm().unwrap();
     /// let vcpu = vm.create_vcpu(0).unwrap();
     ///
-    /// #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-    /// {
-    ///     let debug_struct = kvm_guest_debug {
-    ///         // Configure the vcpu so that a KVM_DEBUG_EXIT would be generated
-    ///         // when encountering a software breakpoint during execution
-    ///         control: KVM_GUESTDBG_ENABLE | KVM_GUESTDBG_USE_SW_BP,
-    ///         pad: 0,
-    ///         // Reset all arch-specific debug registers
-    ///         arch: Default::default(),
-    ///     };
+    /// let debug_struct = kvm_guest_debug {
+    ///     // Configure the vcpu so that a KVM_DEBUG_EXIT would be generated
+    ///     // when encountering a software breakpoint during execution
+    ///     control: KVM_GUESTDBG_ENABLE | KVM_GUESTDBG_USE_SW_BP,
+    ///     pad: 0,
+    ///     // Reset all arch-specific debug registers
+    ///     arch: Default::default(),
+    /// };
     ///
-    ///     vcpu.set_guest_debug(&debug_struct).unwrap();
-    /// }
+    /// vcpu.set_guest_debug(&debug_struct).unwrap();
     /// ```
     #[cfg(any(
         target_arch = "x86_64",

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -1474,7 +1474,6 @@ impl VmFd {
     ///
     /// let guest_memfd = vm.create_guest_memfd(gmem).unwrap();
     /// ```
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn create_guest_memfd(&self, gmem: kvm_create_guest_memfd) -> Result<RawFd> {
         // SAFETY: Safe because we know that our file is a VM fd, we know the kernel will only
         // read the correct amount of memory from our pointer, and we verify the return result.

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -50,7 +50,6 @@ ioctl_io_nr!(KVM_SET_TSS_ADDR, KVMIO, 0x47);
 /* Available with KVM_CAP_SET_IDENTITY_MAP_ADDR */
 #[cfg(target_arch = "x86_64")]
 ioctl_iow_nr!(KVM_SET_IDENTITY_MAP_ADDR, KVMIO, 0x48, u64);
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 ioctl_iowr_nr!(KVM_CREATE_GUEST_MEMFD, KVMIO, 0xd4, kvm_create_guest_memfd);
 /* Available with KVM_CAP_IRQCHIP */
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "s390x"))]


### PR DESCRIPTION
### Summary of the PR

This is a follow up to #208 (it came up during review, but was definitely out of scope there):

- Hide cfg(target_arch = "...") from `cargo doc` output, as it's clutter, and the indentation it comes with is somewhat unsightly imo
- Remove cfgs if they're not needed in the first place (either because the function the doctest is attached to is already cfg'd, or because the doctest works on all supported architectures)
- Refactor some doc test to work on more architectures (guest_memfd related doctests mostly, in anticipation that it'll be supported on ARM eventually)
- 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
