### PR TITLE
doc: Adjust READMEs after repository merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+[![Build Status](https://badge.buildkite.com/9e0e6c88972a3248a0908506d6946624da84e4e18c0870c4d0.svg)](https://buildkite.com/rust-vmm/kvm-ioctls-ci)
+
+# kvm
+
+The `kvm` workspace hosts libraries related to Rust bindings to the Kernel Virtual Machine (KVM). It currently consists of the following crates:
+
+- `kvm-bindings` -> Rust FFI bindings to KVM
+- `kvm-ioctls` -> Safe wrappers over the KVM API
+
+## Running the tests
+
+Our Continuous Integration (CI) pipeline is implemented on top of
+[Buildkite](https://buildkite.com/).
+For the complete list of tests, check our
+[CI pipeline](https://buildkite.com/rust-vmm/kvm-ci).
+
+Each individual test runs in a container. To reproduce a test locally, you can
+use the dev-container on x86_64, arm64 and riscv64.
+
+```bash
+# For running riscv64 tests, replace v47 with v47-riscv. This provides an
+# emulated riscv64 environment on a x86_64 host.
+docker run --device=/dev/kvm \
+           -it \
+           --security-opt seccomp=unconfined \
+           --volume $(pwd)/kvm:/kvm \
+           rustvmm/dev:v47
+cd kvm-ioctls/
+cargo test
+```
+
+For more details about the integration tests that are run for `kvm`,
+check the [rust-vmm-ci](https://github.com/rust-vmm/rust-vmm-ci) readme. 

--- a/kvm-bindings/README.md
+++ b/kvm-bindings/README.md
@@ -1,5 +1,4 @@
-[![Crates.io](https://img.shields.io/crates/v/kvm-bindings.svg)](https://crates.io/crates/kvm-bindings)
-![](https://img.shields.io/crates/l/kvm-bindings.svg)
+[![Crates.io](https://img.shields.io/crates/v/kvm-bindings.svg)]
 # kvm-bindings
 Rust FFI bindings to KVM, generated using
 [bindgen](https://crates.io/crates/bindgen). It currently has support for the
@@ -17,30 +16,16 @@ kernel version they are using. For example, the `immediate_exit` field from the
 capability is available. Using invalid fields or features may lead to undefined
 behaviour.
 
-## Usage
-First, add the following to your `Cargo.toml`:
-```toml
-kvm-bindings = "0.3"
-```
-Next, add this to your crate root:
-```rust
-extern crate kvm_bindings;
-```
+### Flexible Array Members (FAM structs)
 
-This crate also offers safe wrappers over FAM structs - FFI structs that have
-a Flexible Array Member in their definition.
-These safe wrappers can be used if the `fam-wrappers` feature is enabled for
-this crate. Example:
-```toml
-kvm-bindings = { version = "0.3", features = ["fam-wrappers"]}
-```
+This crate optionally offers safe wrappers over FAM structs - FFI structs that
+have a Flexible Array Member in their definition.  These safe wrappers can be
+used if the `fam-wrappers` feature is enabled for this crate. Note that
+enabling the `fam-wrappers` feature enables the `vmm-sys-util` dependency.
 
-## Dependencies
-The crate has an `optional` dependency to
-[vmm-sys-util](https://crates.io/crates/vmm-sys-util) when enabling the
-`fam-wrappers` feature.
+## Serialization
 
-It also has an optional dependency on [`serde`](serde.rs) when enabling the 
+It has an optional dependency on [`serde`](serde.rs) when enabling the 
 `serde` feature, to allow serialization of bindings. Serialization of
 bindings happens as opaque binary blobs via [`zerocopy`](https://google.github.io/comprehensive-rust/bare-metal/useful-crates/zerocopy.html).
 Due to the kernel's ABI compatibility, this means that bindings serialized

--- a/kvm-ioctls/README.md
+++ b/kvm-ioctls/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://badge.buildkite.com/9e0e6c88972a3248a0908506d6946624da84e4e18c0870c4d0.svg)](https://buildkite.com/rust-vmm/kvm-ioctls-ci)
 [![crates.io](https://img.shields.io/crates/v/kvm-ioctls.svg)](https://crates.io/crates/kvm-ioctls)
 
 # kvm-ioctls
@@ -20,27 +19,4 @@ as the code documentation.
 
 The kvm-ioctls can be used on x86_64, aarch64 and riscv64 (experimental).
 
-## Running the tests
 
-Our Continuous Integration (CI) pipeline is implemented on top of
-[Buildkite](https://buildkite.com/).
-For the complete list of tests, check our
-[CI pipeline](https://buildkite.com/rust-vmm/kvm-ioctls-ci).
-
-Each individual test runs in a container. To reproduce a test locally, you can
-use the dev-container on x86_64, arm64 and riscv64.
-
-```bash
-# For running riscv64 tests, replace v47 with v47-riscv. This provides an
-# emulated riscv64 environment on a x86_64 host.
-docker run --device=/dev/kvm \
-           -it \
-           --security-opt seccomp=unconfined \
-           --volume $(pwd)/kvm-ioctls:/kvm-ioctls \
-           rustvmm/dev:v47
-cd kvm-ioctls/
-cargo test
-```
-
-For more details about the integration tests that are run for `kvm-ioctls`,
-check the [rust-vmm-ci](https://github.com/rust-vmm/rust-vmm-ci) readme.


### PR DESCRIPTION
Create a shallow top-level README in the style of the rust-vmm/vhost README. Leave the individual repository READMEs alone mostly (as these will appear on crates.io), but do slight adjustments to reflect the new repository structure:
- move "how to run tests" section to top level and adjust URLs with new name
- Cleanup kvm-bindings README slightly to drop instruction for how to add it to your project, because crates.io already provides that info.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
