### PR TITLE
fix: use correct ioctl wrapper for `create_device`

### DIFF
--- a/kvm-ioctls/CHANGELOG.md
+++ b/kvm-ioctls/CHANGELOG.md
@@ -7,6 +7,12 @@
 - [[#288](https://github.com/rust-vmm/kvm-ioctls/pull/288)]: Introduce `Cap::GuestMemfd`, `Cap::MemoryAttributes` and 
    `Cap::UserMemory2` capabilities enum variants for use with `VmFd::check_extension`.
 
+### Fixed
+
+- [[#298](https://github.com/rust-vmm/kvm/pull/298)]: Fixed incorrect usage of `ioctl_wit_ref` in the
+  `create_device` method. Replace it with `ioctl_wit_mut_ref` as the passed parameter may be mutated by the
+  ioctl.
+
 ## v0.19.0
 
 ### Added

--- a/kvm-ioctls/src/ioctls/vm.rs
+++ b/kvm-ioctls/src/ioctls/vm.rs
@@ -22,11 +22,11 @@ use crate::ioctls::{KvmRunWrapper, Result};
 use crate::kvm_ioctls::*;
 use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::EventFd;
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+use vmm_sys_util::ioctl::ioctl;
 #[cfg(target_arch = "x86_64")]
 use vmm_sys_util::ioctl::ioctl_with_mut_ptr;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-use vmm_sys_util::ioctl::{ioctl, ioctl_with_mut_ref};
-use vmm_sys_util::ioctl::{ioctl_with_ref, ioctl_with_val};
+use vmm_sys_util::ioctl::{ioctl_with_mut_ref, ioctl_with_ref, ioctl_with_val};
 
 /// An address either in programmable I/O space or in memory mapped I/O space.
 ///
@@ -1300,7 +1300,7 @@ impl VmFd {
     /// ```
     pub fn create_device(&self, device: &mut kvm_create_device) -> Result<DeviceFd> {
         // SAFETY: Safe because we are calling this with the VM fd and we trust the kernel.
-        let ret = unsafe { ioctl_with_ref(self, KVM_CREATE_DEVICE(), device) };
+        let ret = unsafe { ioctl_with_mut_ref(self, KVM_CREATE_DEVICE(), device) };
         if ret == 0 {
             // SAFETY: We validated the return of the function creating the fd and we trust the
             // kernel.


### PR DESCRIPTION
### Summary of the PR

Use `ioctl_with_mut_ref` instead of `ioctl_with_ref` for `create_device` as it needs to write to the
`kvm_create_device` struct passed to it.

This incorrect usage of the `ioctl_with_ref` causes an issue if used with Rust version 1.82(and later) in `release` builds. In those cases the `kvm_create_device` struct is considered to be immutable and the following `File::from_raw_fd` creates a file from an initial value set in the `kvm_create_device` before the call.

The reason unit tests don't fail in CI is because it uses 1.80.1 version and does not run unit tests with `--release` option which does not produce the error.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
