### PR TITLE
Backport #298 to kvm-ioctls 0.19 and prepare 0.19.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Upcoming Release
 
+## v0.19.1
+
 ### Fixed
 
 - [[#298](https://github.com/rust-vmm/kvm/pull/298)]: Fixed incorrect usage of `ioctl_wit_ref` in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Upcoming Release
 
+### Fixed
+
+- [[#298](https://github.com/rust-vmm/kvm/pull/298)]: Fixed incorrect usage of `ioctl_wit_ref` in the
+  `create_device` method. Replace it with `ioctl_wit_mut_ref` as the passed parameter may be mutated by the
+  ioctl.
+
 ## v0.19.0
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvm-ioctls"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["Amazon Firecracker Team <firecracker-maintainers@amazon.com>"]
 description = "Safe wrappers over KVM ioctls"
 repository = "https://github.com/rust-vmm/kvm-ioctls"

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -22,11 +22,11 @@ use crate::ioctls::{KvmRunWrapper, Result};
 use crate::kvm_ioctls::*;
 use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::EventFd;
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+use vmm_sys_util::ioctl::ioctl;
 #[cfg(target_arch = "x86_64")]
 use vmm_sys_util::ioctl::ioctl_with_mut_ptr;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-use vmm_sys_util::ioctl::{ioctl, ioctl_with_mut_ref};
-use vmm_sys_util::ioctl::{ioctl_with_ref, ioctl_with_val};
+use vmm_sys_util::ioctl::{ioctl_with_mut_ref, ioctl_with_ref, ioctl_with_val};
 
 /// An address either in programmable I/O space or in memory mapped I/O space.
 ///
@@ -1306,7 +1306,7 @@ impl VmFd {
     /// ```
     pub fn create_device(&self, device: &mut kvm_create_device) -> Result<DeviceFd> {
         // SAFETY: Safe because we are calling this with the VM fd and we trust the kernel.
-        let ret = unsafe { ioctl_with_ref(self, KVM_CREATE_DEVICE(), device) };
+        let ret = unsafe { ioctl_with_mut_ref(self, KVM_CREATE_DEVICE(), device) };
         if ret == 0 {
             // SAFETY: We validated the return of the function creating the fd and we trust the
             // kernel.


### PR DESCRIPTION
### Summary of the PR

Backport https://github.com/rust-vmm/kvm/pull/298 from main and prepare new 0.19.1 release.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
