### PR TITLE
feat: have dependabot also make PRs for rust dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,25 @@
 version: 2
 updates:
+
+# A monthly update of the rust-vmm-ci submodule
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:
     interval: monthly
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 1
+
+# A monthly update to rust dependencies. These will be grouped,
+# e.g. one PR will contains updates for all dependencies.
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 1
+  # Make it also update transitive dependencies in Cargo.lock
+  allow:
+    - dependency-type: "all"
+  # Group all available updates into a group called "rust-dependencies"
+  groups:
+    rust-dependencies:
+      patterns:
+        - "*"


### PR DESCRIPTION
Use the dependabot template from rust-vmm-ci, so that we get grouped dependabot PRs for rust dependencies once a month (I noticed the other day that we're a major version behind in terms of zerocopy, so enabling dependabot makes sense imo).

Also fixes the open pr limit for the rust-vmm-ci submodule to 1 (from 10).

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
