### PR TITLE
feat: Bump KVM_MAX_CPUID_ENTRIES to 256

### DIFF
--- a/kvm-bindings/CHANGELOG.md
+++ b/kvm-bindings/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Changed
 
+- Updated KVM_MAX_CPUID_ENTRIES to 256.
+
 ### Removed
 
 ## [0.10.0]

--- a/kvm-bindings/src/x86_64/fam_wrappers.rs
+++ b/kvm-bindings/src/x86_64/fam_wrappers.rs
@@ -8,7 +8,7 @@ use x86_64::bindings::*;
 /// Maximum number of CPUID entries that can be returned by a call to KVM ioctls.
 ///
 /// See arch/x86/include/asm/kvm_host.h
-pub const KVM_MAX_CPUID_ENTRIES: usize = 80;
+pub const KVM_MAX_CPUID_ENTRIES: usize = 256;
 
 /// Maximum number of MSRs KVM supports (See arch/x86/kvm/x86.c).
 pub const KVM_MAX_MSR_ENTRIES: usize = 256;


### PR DESCRIPTION
### Summary of the PR
From 5.10 this constant has been updated from 80 to 256. Update the constant to reflect this.

https://elixir.bootlin.com/linux/v5.10.232/source/arch/x86/include/asm/kvm_host.h#L136

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
