### PR TITLE
Add support for KVM_GET_XSAVE2

### DIFF
--- a/kvm-ioctls/CHANGELOG.md
+++ b/kvm-ioctls/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 ## Upcoming Release
 
+### Added
+
+- [[#310](https://github.com/rust-vmm/kvm/pull/310)]: Added support for
+  `KVM_CAP_XSAVE2` and the `KVM_GET_XSAVE2` ioctl.
+
 ## v0.20.0
 
-### Added 
+### Added
 
-- [[#288](https://github.com/rust-vmm/kvm-ioctls/pull/288)]: Introduce `Cap::GuestMemfd`, `Cap::MemoryAttributes` and 
+- [[#288](https://github.com/rust-vmm/kvm-ioctls/pull/288)]: Introduce `Cap::GuestMemfd`, `Cap::MemoryAttributes` and
    `Cap::UserMemory2` capabilities enum variants for use with `VmFd::check_extension`.
 - [[#288](https://github.com/rust-vmm/kvm-ioctls/pull/288)]: Introduce `VmFd::check_extension_raw` and `VmFd::check_extension_int` to allow `KVM_CHECK_EXTENSION` to return integer.
 

--- a/kvm-ioctls/CHANGELOG.md
+++ b/kvm-ioctls/CHANGELOG.md
@@ -7,6 +7,14 @@
 - [[#310](https://github.com/rust-vmm/kvm/pull/310)]: Added support for
   `KVM_CAP_XSAVE2` and the `KVM_GET_XSAVE2` ioctl.
 
+### Changed
+
+- [[#310](https://github.com/rust-vmm/kvm/pull/310)]: Changed `set_xsave()`
+  `unsafe` because the C `kvm_xsave` struct was extended to have a flexible
+  array member (FAM) in the end in Linux 5.16 and `KVM_SET_XSAVE` may copy data
+  beyond the traditional size (i.e. 4096 bytes). If any features are enabled
+  dynamically on Linux 5.16+, it is recommended to use `set_xsave2()` instead.
+
 ## v0.20.0
 
 ### Added

--- a/kvm-ioctls/src/cap.rs
+++ b/kvm-ioctls/src/cap.rs
@@ -82,6 +82,8 @@ pub enum Cap {
     #[cfg(target_arch = "x86_64")]
     Xsave = KVM_CAP_XSAVE,
     #[cfg(target_arch = "x86_64")]
+    Xsave2 = KVM_CAP_XSAVE2,
+    #[cfg(target_arch = "x86_64")]
     Xcrs = KVM_CAP_XCRS,
     PpcGetPvinfo = KVM_CAP_PPC_GET_PVINFO,
     PpcIrqLevel = KVM_CAP_PPC_IRQ_LEVEL,

--- a/kvm-ioctls/src/kvm_ioctls.rs
+++ b/kvm-ioctls/src/kvm_ioctls.rs
@@ -198,6 +198,9 @@ ioctl_iow_nr!(KVM_SET_DEBUGREGS, KVMIO, 0xa2, kvm_debugregs);
 /* Available with KVM_CAP_XSAVE */
 #[cfg(target_arch = "x86_64")]
 ioctl_ior_nr!(KVM_GET_XSAVE, KVMIO, 0xa4, kvm_xsave);
+/* Available with KVM_CAP_XSAVE2 */
+#[cfg(target_arch = "x86_64")]
+ioctl_ior_nr!(KVM_GET_XSAVE2, KVMIO, 0xcf, kvm_xsave);
 /* Available with KVM_CAP_XSAVE */
 #[cfg(target_arch = "x86_64")]
 ioctl_iow_nr!(KVM_SET_XSAVE, KVMIO, 0xa5, kvm_xsave);


### PR DESCRIPTION
### Summary of the PR

Since Linux 5.17, the `kvm_xsave` struct has a flexiblre array member
(FAM) at the end, which can be retrieved using the `KVM_GET_XSAVE2`
ioctl [1]. What makes this FAM special is that the length is not stored
in itself, but has to be retrieved via
`KVM_CHECK_CAPABILITY(KVM_CAP_XSAVE2)` which returns the total size of
the `kvm_xsave` struct (e.g. the traditional 4096 byte region + extra
region with the size of the FAM). To support it in rust-vmm, `Xsave` has
been introduced as its `FamStructWrapper`.
    
The size required to hold the whole `kvm_xsave` structure can vary
depending on features that have been dynamically enabled by
`arch_prctl()` [2]. Any features must not be enabled after the size has
been confirmed; otherwise, `KVM_GET_XSAVE2` writes beyond the allocated
area for `Xsave`, potentially causing undefined behavior. It is unable
to put `KVM_CHECK_CAPABILITY` call for the size check and
`KVM_GET_XSAVE2` call together into `get_xsave2()`, because there is a
chance of race condition where another thread enables additional
features between them. That's why `get_xsave2()` is marked `unsafe`.
    
Although `KVM_SET_XSAVE` was extended and `KVM_SET_XSAVE2` was not added
to support the `kvm_xsave` with FAM, `set_xsave2()` is also implemented
to enable users to pass `Xsave` to it for convenience. That is also
marked `unsafe` for the same reason.

In addition to that, after Linux 5.17, the existing `set_xsave2()` may copy data
beyond the traditional 4096 bytes if XSTATE features are dynamically enabled.
So it is also marked `unsafe`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
