### PR TITLE
Prepare new release for kvm-ioctls

### DIFF
--- a/kvm-ioctls/CHANGELOG.md
+++ b/kvm-ioctls/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Upcoming Release
 
+## v0.21.0
+
 ### Added
 
 - [[#310](https://github.com/rust-vmm/kvm/pull/310)]: Added support for

--- a/kvm-ioctls/Cargo.toml
+++ b/kvm-ioctls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvm-ioctls"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Amazon Firecracker Team <firecracker-maintainers@amazon.com>"]
 description = "Safe wrappers over KVM ioctls"
 repository = "https://github.com/rust-vmm/kvm"


### PR DESCRIPTION
### Summary of the PR

Bump kvm-ioctls version from 0.20.0 to 0.21.0 since `set_xsave()` was mark `unsafe` and that is a breaking change.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
