### PR TITLE
Minor QoL improvements for kvm_xsave2

### DIFF
--- a/kvm-bindings/src/x86_64/fam_wrappers.rs
+++ b/kvm-bindings/src/x86_64/fam_wrappers.rs
@@ -113,6 +113,12 @@ pub struct kvm_xsave2 {
     pub xsave: kvm_xsave,
 }
 
+impl From<kvm_xsave> for kvm_xsave2 {
+    fn from(xsave: kvm_xsave) -> Self {
+        kvm_xsave2 { len: 0, xsave }
+    }
+}
+
 // SAFETY:
 // - `kvm_xsave2` is a POD
 // - `kvm_xsave2` contains a flexible array member as its final field, due to `kvm_xsave` containing

--- a/kvm-bindings/src/x86_64/fam_wrappers.rs
+++ b/kvm-bindings/src/x86_64/fam_wrappers.rs
@@ -104,11 +104,14 @@ pub type MsrList = FamStructWrapper<kvm_msr_list>;
     derive(zerocopy::AsBytes, zerocopy::FromBytes, zerocopy::FromZeroes)
 )]
 pub struct kvm_xsave2 {
-    /// The length, in bytes, of the FAM in [`kvm_xsave`].
+    /// The length, in units of sizeof::<__u32>(), of the FAM in [`kvm_xsave`].
     ///
     /// Note that `KVM_CHECK_EXTENSION(KVM_CAP_XSAVE2)` returns the size of the entire
     /// `kvm_xsave` structure, e.g. the sum of header and FAM. Thus, this `len` field
-    /// is equal to `KVM_CHECK_EXTENSION(KVM_CAP_XSAVE2) - 4096`.
+    /// is equal to
+    /// ```norun
+    /// (KVM_CHECK_EXTENSION(KVM_CAP_XSAVE2) - sizeof::<kvm_xsave>()).div_ceil(sizeof::<__u32>())
+    /// ```
     pub len: usize,
     pub xsave: kvm_xsave,
 }


### PR DESCRIPTION
- add a way to convert kvm_xsave to kvm_xsave2 more easily
- fix the doc comment on kvm_xsave2.len

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
