### PR TITLE
build: Bump `rust-vmm-ci` to `c3ef897`

### DIFF
--- a/kvm-ioctls/src/ioctls/vcpu.rs
+++ b/kvm-ioctls/src/ioctls/vcpu.rs
@@ -3584,12 +3584,12 @@ mod tests {
             .as_slice()
             .iter()
             .find(|entry| entry.function == 1)
-            .map_or(false, |entry| entry.ecx & (1 << 5) != 0);
+            .is_some_and(|entry| entry.ecx & (1 << 5) != 0);
         let supports_vmmcall = cpuid
             .as_slice()
             .iter()
             .find(|entry| entry.function == 0x8000_0001)
-            .map_or(false, |entry| entry.ecx & (1 << 2) != 0);
+            .is_some_and(|entry| entry.ecx & (1 << 2) != 0);
         #[rustfmt::skip]
         let code = if supports_vmcall {
             [

--- a/kvm-ioctls/src/ioctls/vcpu.rs
+++ b/kvm-ioctls/src/ioctls/vcpu.rs
@@ -3476,7 +3476,7 @@ mod tests {
         let mut kvi: kvm_vcpu_init = kvm_vcpu_init::default();
         vm.get_preferred_target(&mut kvi)
             .expect("Cannot get preferred target");
-        kvi.features[0] |= 1 << KVM_ARM_VCPU_PSCI_0_2 | 1 << KVM_ARM_VCPU_PMU_V3;
+        kvi.features[0] |= (1 << KVM_ARM_VCPU_PSCI_0_2) | (1 << KVM_ARM_VCPU_PMU_V3);
         vcpu.vcpu_init(&kvi).unwrap();
         vcpu.has_device_attr(&dist_attr).unwrap();
         vcpu.set_device_attr(&dist_attr).unwrap();


### PR DESCRIPTION
### Summary of the PR

`bincode` is requiring rust toolchain with version >= 1.85.0, bump `rust-vmm-ci` to catch up.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
