### PR TITLE
cap: add X2ApicApi capability.

### DIFF
--- a/kvm-ioctls/CHANGELOG.md
+++ b/kvm-ioctls/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Upcoming Release
 
+- Plumb through KVM_CAP_X2APIC_API as X2ApicApi cap.
+
 ## v0.23.0
 
 ### Added

--- a/kvm-ioctls/src/cap.rs
+++ b/kvm-ioctls/src/cap.rs
@@ -167,4 +167,6 @@ pub enum Cap {
     MemoryAttributes = KVM_CAP_MEMORY_ATTRIBUTES,
     #[cfg(target_arch = "x86_64")]
     NestedState = KVM_CAP_NESTED_STATE,
+    #[cfg(target_arch = "x86_64")]
+    X2ApicApi = KVM_CAP_X2APIC_API,
 }


### PR DESCRIPTION
The capability is used to program/remap MSI IRQ routing to vCPUs with IDs larger than 255.

### Summary of the PR

I'm working on a PR to Cloud Hypervisor to allow it to run VMs with more than 256 vCPUs. KVM on x86_64 needs KVM_CAP_X2APIC_API capability to properly route IRQs to CPUs with APIC IDs larger than 255; as Cloud Hypvervisor depends on this crate for KVM capability management, this small change is needed to avoid ugly workarounds. 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [-] All added/changed functionality has a corresponding unit/integration
  test:
  - This is just plumbing through a constant generated from a C header file; there are no functional changes.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [N/A] Any newly added `unsafe` code is properly documented.
