### PR TITLE
Add support for vm device_attr ioctls on aarch64

### DIFF
--- a/kvm-ioctls/CHANGELOG.md
+++ b/kvm-ioctls/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Upcoming Release
 
+### Added
+
 - Plumb through KVM_CAP_X2APIC_API as X2ApicApi cap.
+- [[#334]](https://github.com/rust-vmm/kvm/pull/334) Added support for
+  `KVM_HAS_DEVICE_ATTR` and `KVM_SET_DEVICE_ATTR` vm ioctl on aarch64.
 
 ## v0.23.0
 


### PR DESCRIPTION
### Summary of the PR

Add support for `HAS_DEVICE_ATTR` and `SET_DEVICE_ATTR` vm ioctls on
aarch64, which were introduced in linux 6.4 to support configuring SMCCC
filter. SMCCC filter could be used to forward selected SMCs or HVCs to
userspace for handling. For example, to implement vCPU hotplug/hotunplug
on aarch64, it's required to forward PSCI calls to userspace for handling.


### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
