### PR TITLE
dependabot: drop open-pull-request-limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
   directory: "/"
   schedule:
     interval: monthly
-  open-pull-requests-limit: 1
 
 # A monthly update to rust dependencies. These will be grouped,
 # e.g. one PR will contains updates for all dependencies.
@@ -14,7 +13,6 @@ updates:
   directory: "/"
   schedule:
     interval: monthly
-  open-pull-requests-limit: 1
   # Make it also update transitive dependencies in Cargo.lock
   allow:
     - dependency-type: "all"


### PR DESCRIPTION
Currently, dependabot is for some reason stuck saying  "Dependabot cannot open any more pull requests" (the error message one gets if there are many than open-pull-request-limit dependabot PRs open), despite there being exactly 0 open dependabot PRs. We also cannot manually trigger it, as it fails with the same reason.

Try to resolve this by removing the limit on pull requests. In practice, this should not matter, as we have exactly 1 submodule, and the cargo dependencies are all grouped, meaning simply based on how dependabot functions, we never get more than one concurrent PR of each type anyway.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
