### PR TITLE
chore: Prepare kvm-bindings@0.14.0 and kvm-ioclts@0.24.0 release

### DIFF
--- a/.github/workflows/publish-kvm-bindings.yaml
+++ b/.github/workflows/publish-kvm-bindings.yaml
@@ -1,0 +1,21 @@
+name: Publish kvm-bindings to crates.io
+
+on:
+  push:
+    tags: ['kvm-bindings-v*']  # Triggers when pushing tags starting with 'kvm-bindings-v'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # environment: release  # Optional: for enhanced security
+    permissions:
+      id-token: write     # Required for OIDC token exchange
+    steps:
+    - uses: actions/checkout@v4
+    - uses: rust-lang/crates-io-auth-action@v1
+      id: auth
+    - run: |
+        cd kvm-bindings
+        cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/publish-kvm-ioctls.yaml
+++ b/.github/workflows/publish-kvm-ioctls.yaml
@@ -1,0 +1,21 @@
+name: Publish kvm-ioctls to crates.io
+
+on:
+  push:
+    tags: ['kvm-ioctls-v*']  # Triggers when pushing tags starting with 'kvm-ioctls-v'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # environment: release  # Optional: for enhanced security
+    permissions:
+      id-token: write     # Required for OIDC token exchange
+    steps:
+    - uses: actions/checkout@v4
+    - uses: rust-lang/crates-io-auth-action@v1
+      id: auth
+    - run: |
+        cd kvm-ioctls
+        cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ members = [
 ]
 
 [workspace.dependencies]
-vmm-sys-util = "0.14.0"
+vmm-sys-util = ">=0.14, <=0.15"

--- a/kvm-bindings/CHANGELOG.md
+++ b/kvm-bindings/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Upcoming Release
 
+## v0.14.0
+
 ### Changed
+
 - Rust edition 2024
 
 ## v0.13.0

--- a/kvm-bindings/Cargo.toml
+++ b/kvm-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvm-bindings"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 description = "Rust FFI bindings to KVM generated using bindgen."
 repository = "https://github.com/rust-vmm/kvm"

--- a/kvm-ioctls/CHANGELOG.md
+++ b/kvm-ioctls/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Upcoming Release
 
+## v0.24.0
+
 ### Added
 
 - Plumb through KVM_CAP_X2APIC_API as X2ApicApi cap.

--- a/kvm-ioctls/Cargo.toml
+++ b/kvm-ioctls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvm-ioctls"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Amazon Firecracker Team <firecracker-maintainers@amazon.com>"]
 description = "Safe wrappers over KVM ioctls"
 repository = "https://github.com/rust-vmm/kvm"
@@ -12,7 +12,7 @@ rust-version.workspace = true
 
 [dependencies]
 libc = "0.2.39"
-kvm-bindings = { path = "../kvm-bindings", version = "0.13.0", features = ["fam-wrappers"] }
+kvm-bindings = { path = "../kvm-bindings", version = "0.14.0", features = ["fam-wrappers"] }
 vmm-sys-util = { workspace = true }
 bitflags = "2.4.1"
 


### PR DESCRIPTION
### Summary of the PR

Release kvm-bindings v0.14.0 and kvm-ioctls v0.24.0 to consume Rust edition change and newly exposed X2ApicApi capability.

Waiting for #338 to be merged first.

Relates: #339 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
