### PR TITLE
cap: add DirtyLogRing cap

### DIFF
--- a/kvm-ioctls/CHANGELOG.md
+++ b/kvm-ioctls/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Upcoming Release
 
+- Plumb through KVM_CAP_DIRTY_LOG_RING as DirtyLogRing cap.
+
 ## v0.24.0
 
 ### Added

--- a/kvm-ioctls/src/cap.rs
+++ b/kvm-ioctls/src/cap.rs
@@ -169,4 +169,5 @@ pub enum Cap {
     NestedState = KVM_CAP_NESTED_STATE,
     #[cfg(target_arch = "x86_64")]
     X2ApicApi = KVM_CAP_X2APIC_API,
+    DirtyLogRing = KVM_CAP_DIRTY_LOG_RING,
 }


### PR DESCRIPTION
Add the DirtyLogRing cap.

### Summary of the PR

The capability is used for the KVM dirty ring interface for tracking dirtied pages.

