### PR TITLE
backport get_nested_state() to kvm-ioctls@0.22.1 and kvm-bindings@0.12.1

### DIFF
--- a/kvm-bindings/CHANGELOG.md
+++ b/kvm-bindings/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.12.1]
+
+### Added
+
+- Added `KvmNestedStateBuffer`
+
 ### Added
 
 ### Changed

--- a/kvm-bindings/Cargo.toml
+++ b/kvm-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvm-bindings"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 description = "Rust FFI bindings to KVM generated using bindgen."
 repository = "https://github.com/rust-vmm/kvm"

--- a/kvm-bindings/src/lib.rs
+++ b/kvm-bindings/src/lib.rs
@@ -18,6 +18,8 @@ extern crate serde;
 #[cfg(feature = "serde")]
 extern crate zerocopy;
 
+extern crate core;
+
 #[cfg(feature = "serde")]
 #[macro_use]
 mod serialize;

--- a/kvm-bindings/src/x86_64/bindings.rs
+++ b/kvm-bindings/src/x86_64/bindings.rs
@@ -1999,6 +1999,10 @@ impl Default for kvm_vmx_nested_state_data {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(zerocopy::IntoBytes, zerocopy::Immutable, zerocopy::FromBytes)
+)]
 pub struct kvm_vmx_nested_state_hdr {
     pub vmxon_pa: __u64,
     pub vmcs12_pa: __u64,
@@ -2009,6 +2013,10 @@ pub struct kvm_vmx_nested_state_hdr {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(zerocopy::IntoBytes, zerocopy::Immutable, zerocopy::FromBytes)
+)]
 pub struct kvm_vmx_nested_state_hdr__bindgen_ty_1 {
     pub flags: __u16,
 }
@@ -2065,6 +2073,10 @@ impl Default for kvm_svm_nested_state_data {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(zerocopy::IntoBytes, zerocopy::Immutable, zerocopy::FromBytes)
+)]
 pub struct kvm_svm_nested_state_hdr {
     pub vmcb_pa: __u64,
 }
@@ -2087,6 +2099,7 @@ pub struct kvm_nested_state {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(zerocopy::Immutable, zerocopy::FromBytes))]
 pub union kvm_nested_state__bindgen_ty_1 {
     pub vmx: kvm_vmx_nested_state_hdr,
     pub svm: kvm_svm_nested_state_hdr,

--- a/kvm-bindings/src/x86_64/mod.rs
+++ b/kvm-bindings/src/x86_64/mod.rs
@@ -6,6 +6,8 @@ pub mod bindings;
 #[cfg(feature = "fam-wrappers")]
 pub mod fam_wrappers;
 
+pub mod nested;
+
 #[cfg(feature = "serde")]
 mod serialize;
 

--- a/kvm-bindings/src/x86_64/nested.rs
+++ b/kvm-bindings/src/x86_64/nested.rs
@@ -1,0 +1,117 @@
+//! Higher-level abstractions for working with nested state.
+//!
+//! Getting and setting the nested KVM state is helpful if nested virtualization
+//! is used and the state needs to be serialized, e.g., for live-migration or
+//! state save/resume. See [`KvmNestedStateBuffer`].
+
+use core::mem;
+use KVM_STATE_NESTED_SVM_VMCB_SIZE;
+use {kvm_nested_state__bindgen_ty_1, KVM_STATE_NESTED_VMX_VMCS_SIZE};
+
+/// Non-zero variant of the bindgen data union.
+///
+/// Please note that on SVM, this type wastes one page as the VMX state is
+/// larger.
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(zerocopy::Immutable, zerocopy::FromBytes))]
+#[repr(C)]
+pub union kvm_nested_state__data {
+    pub vmx: kvm_vmx_nested_state_data,
+    pub svm: kvm_svm_nested_state_data,
+}
+
+impl Default for kvm_nested_state__data {
+    fn default() -> Self {
+        // SAFETY: Every bit pattern is valid.
+        unsafe { mem::zeroed() }
+    }
+}
+
+#[derive(Clone, Copy)]
+#[cfg_attr(
+    feature = "serde",
+    derive(zerocopy::IntoBytes, zerocopy::Immutable, zerocopy::FromBytes)
+)]
+#[repr(C)]
+pub struct kvm_vmx_nested_state_data {
+    pub vmcs12: [u8; KVM_STATE_NESTED_VMX_VMCS_SIZE as usize],
+    pub shadow_vmcs12: [u8; KVM_STATE_NESTED_VMX_VMCS_SIZE as usize],
+}
+
+#[derive(Clone, Copy)]
+#[cfg_attr(
+    feature = "serde",
+    derive(zerocopy::IntoBytes, zerocopy::Immutable, zerocopy::FromBytes)
+)]
+#[repr(C)]
+pub struct kvm_svm_nested_state_data {
+    pub vmcb12: [u8; KVM_STATE_NESTED_SVM_VMCB_SIZE as usize],
+}
+
+/// A stack-allocated buffer for nested KVM state including the mandatory
+/// header with meta-information.
+///
+/// KVM uses a dynamically sized buffer structure (with a header reporting the
+/// size of the buffer/state). This helper type makes working with
+/// `get_nested_state()` and `set_nested_state`() significantly more convenient
+/// at the cost of a slightly higher memory footprint in some cases.
+///
+/// # Type Size
+///
+/// On Intel VMX, the actual state requires `128 + 8192 == 8320` bytes, on
+/// AMD SVM, the actual state requires `128 + 4096 == 4224` bytes. This type
+/// doesn't make a differentiation and unifies the required memory. By
+/// sacrificing a few more bytes on VMX, this type is generally convenient to
+/// use.
+#[derive(Clone, Copy)]
+#[cfg_attr(
+    feature = "serde",
+    derive(zerocopy::IntoBytes, zerocopy::Immutable, zerocopy::FromBytes)
+)]
+#[repr(C)]
+#[non_exhaustive] // Prevent constructor bypass in public API.
+pub struct KvmNestedStateBuffer {
+    pub flags: u16,
+    pub format: u16,
+    pub size: u32,
+    pub hdr: kvm_nested_state__bindgen_ty_1,
+    pub data: kvm_nested_state__data,
+}
+
+impl KvmNestedStateBuffer {
+    /// Creates a new empty buffer, ready for nested state to be stored in by KVM.
+    ///
+    /// The `size` property will report the size of the buffer to KVM.
+    pub fn empty() -> Self {
+        // SAFETY: Every bit pattern is valid.
+        let mut this: KvmNestedStateBuffer = unsafe { mem::zeroed() };
+        // This way, KVM knows the size of the buffer to store state into.
+        // See: https://elixir.bootlin.com/linux/v6.12/source/arch/x86/kvm/x86.c#L6193
+        this.size = size_of::<Self>() as u32;
+        this
+    }
+}
+
+impl Default for KvmNestedStateBuffer {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::kvm_nested_state as kvm_nested_state_raw_binding;
+
+    #[test]
+    fn test_layout() {
+        assert_eq!(
+            align_of::<kvm_nested_state_raw_binding>(),
+            align_of::<KvmNestedStateBuffer>()
+        );
+        assert!(size_of::<KvmNestedStateBuffer>() > size_of::<kvm_nested_state_raw_binding>());
+        // When this fails/changes, we should re-evaluate the overall types and API
+        assert_eq!(size_of::<KvmNestedStateBuffer>(), 8320);
+    }
+}

--- a/kvm-bindings/src/x86_64/serialize.rs
+++ b/kvm-bindings/src/x86_64/serialize.rs
@@ -10,6 +10,8 @@ use bindings::{
     kvm_xcr, kvm_xcrs, kvm_xsave,
 };
 use fam_wrappers::kvm_xsave2;
+use kvm_nested_state__bindgen_ty_1;
+use nested::{kvm_nested_state__data, KvmNestedStateBuffer};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use zerocopy::{transmute, FromBytes, FromZeros, Immutable, IntoBytes};
 
@@ -35,7 +37,8 @@ serde_impls!(
     kvm_xsave2,
     kvm_irqchip,
     kvm_irq_routing,
-    kvm_irq_routing_entry
+    kvm_irq_routing_entry,
+    KvmNestedStateBuffer
 );
 
 // SAFETY: zerocopy's derives explicitly disallow deriving for unions where
@@ -122,6 +125,30 @@ unsafe impl IntoBytes for kvm_irq_routing_entry__bindgen_ty_1 {
     }
 }
 
+// SAFETY: zerocopy's derives explicitly disallow deriving for unions where
+// the fields have different sizes, due to the smaller fields having padding.
+// Miri however does not complain about these implementations (e.g. about
+// reading the "padding" for one union field as valid data for a bigger one)
+unsafe impl IntoBytes for kvm_nested_state__bindgen_ty_1 {
+    fn only_derive_is_allowed_to_implement_this_trait()
+    where
+        Self: Sized,
+    {
+    }
+}
+
+// SAFETY: zerocopy's derives explicitly disallow deriving for unions where
+// the fields have different sizes, due to the smaller fields having padding.
+// Miri however does not complain about these implementations (e.g. about
+// reading the "padding" for one union field as valid data for a bigger one)
+unsafe impl IntoBytes for kvm_nested_state__data {
+    fn only_derive_is_allowed_to_implement_this_trait()
+    where
+        Self: Sized,
+    {
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -182,6 +209,7 @@ mod tests {
         is_serde::<kvm_mp_state>();
         is_serde::<kvm_irq_routing>();
         is_serde::<kvm_irq_routing_entry>();
+        is_serde::<KvmNestedStateBuffer>();
     }
 
     fn is_serde_json<T: Serialize + for<'de> Deserialize<'de> + Default>() {
@@ -216,5 +244,6 @@ mod tests {
         is_serde_json::<kvm_mp_state>();
         is_serde_json::<kvm_irq_routing>();
         is_serde_json::<kvm_irq_routing_entry>();
+        is_serde_json::<KvmNestedStateBuffer>();
     }
 }

--- a/kvm-ioctls/CHANGELOG.md
+++ b/kvm-ioctls/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Upcoming Release
 
+## v0.22.1
+
+### Added
+
+- Upgrade kvm-bindings to v0.12.1
+- `Vcpu::get_nested_state()` and `Vcpu::set_nested_state()`
+
 ## v0.22.0
 
 ### Changed

--- a/kvm-ioctls/Cargo.toml
+++ b/kvm-ioctls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvm-ioctls"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["Amazon Firecracker Team <firecracker-maintainers@amazon.com>"]
 description = "Safe wrappers over KVM ioctls"
 repository = "https://github.com/rust-vmm/kvm"
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2.39"
-kvm-bindings = { path = "../kvm-bindings", version = "0.12.0", features = ["fam-wrappers"] }
+kvm-bindings = { path = "../kvm-bindings", version = "0.12.1", features = ["fam-wrappers"] }
 vmm-sys-util = { workspace = true }
 bitflags = "2.4.1"
 

--- a/kvm-ioctls/src/cap.rs
+++ b/kvm-ioctls/src/cap.rs
@@ -165,4 +165,6 @@ pub enum Cap {
     UserMemory2 = KVM_CAP_USER_MEMORY2,
     GuestMemfd = KVM_CAP_GUEST_MEMFD,
     MemoryAttributes = KVM_CAP_MEMORY_ATTRIBUTES,
+    #[cfg(target_arch = "x86_64")]
+    NestedState = KVM_CAP_NESTED_STATE,
 }

--- a/kvm-ioctls/src/ioctls/vcpu.rs
+++ b/kvm-ioctls/src/ioctls/vcpu.rs
@@ -2029,7 +2029,8 @@ impl VcpuFd {
         match ret {
             0 => {
                 let size = buffer.size as usize;
-                if size == size_of::<kvm_nested_state /* just the empty header */>() {
+                let just_hdr_size = size_of::<kvm_nested_state>();
+                if size <= just_hdr_size {
                     Ok(None)
                 } else {
                     Ok(Some(NonZeroUsize::new(size).unwrap()))

--- a/kvm-ioctls/src/kvm_ioctls.rs
+++ b/kvm-ioctls/src/kvm_ioctls.rs
@@ -262,6 +262,12 @@ ioctl_iow_nr!(
     kvm_memory_attributes
 );
 
+#[cfg(target_arch = "x86_64")]
+ioctl_iowr_nr!(KVM_GET_NESTED_STATE, KVMIO, 0xbe, kvm_nested_state);
+
+#[cfg(target_arch = "x86_64")]
+ioctl_iow_nr!(KVM_SET_NESTED_STATE, KVMIO, 0xbf, kvm_nested_state);
+
 // Device ioctls.
 
 /* Available with KVM_CAP_DEVICE_CTRL */

--- a/kvm-ioctls/src/lib.rs
+++ b/kvm-ioctls/src/lib.rs
@@ -249,7 +249,7 @@ pub use ioctls::vcpu::reg_size;
 pub use ioctls::vcpu::{HypercallExit, VcpuExit, VcpuFd};
 
 #[cfg(target_arch = "x86_64")]
-pub use ioctls::vcpu::{MsrExitReason, ReadMsrExit, SyncReg, WriteMsrExit};
+pub use ioctls::vcpu::{KvmNestedStateBuffer, MsrExitReason, ReadMsrExit, SyncReg, WriteMsrExit};
 
 pub use ioctls::vm::{IoEventAddress, NoDatamatch, VmFd};
 // The following example is used to verify that our public


### PR DESCRIPTION
### Summary of the PR

**TL;DR**: #322 but backported

As discussed with @roypat at the KVM forum—and as is widely recognized in the community—adding new functionality or updating dependencies is currently quite challenging. For example, Cloud Hypervisor relies on numerous crates that themselves have deep interdependencies with kvm-ioctls and kvm-bindings.

By backporting features and introducing new functionality through a minor release, we can work around these challenges and provide a pragmatic path to incorporate this functionality into Cloud Hypervisor.

### TODOs

- [ ] How should I set up this backport PR? Against which branch should I merge it?

### Test in Cloud Hypervisor

One can test that this works in Cloud Hypervisor with this patch:


<details>

```patch

Subject: [PATCH] xxx
migration: migrate nested guest state
---
Index: Cargo.lock
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/Cargo.lock b/Cargo.lock
--- a/Cargo.lock	(revision ad9a1878bfb79a9a64607bfa613ae916169e1bc2)
+++ b/Cargo.lock	(revision 7d1e6ac25b8c1c99d3069c81188d979c75b46e4d)
@@ -1053,9 +1053,7 @@

[[package]]
name = "kvm-bindings"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b153a59bb3ca930ff8148655b2ef68c34259a623ae08cf2fb9b570b2e45363"
+version = "0.12.1"
dependencies = [
"serde",
"vmm-sys-util",
@@ -1064,9 +1062,7 @@

[[package]]
name = "kvm-ioctls"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b702df98508cb63ad89dd9beb9f6409761b30edca10d48e57941d3f11513a006"
+version = "0.22.1"
dependencies = [
"bitflags 2.9.4",
"kvm-bindings",
Index: Cargo.toml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/Cargo.toml b/Cargo.toml
--- a/Cargo.toml	(revision ad9a1878bfb79a9a64607bfa613ae916169e1bc2)
+++ b/Cargo.toml	(revision 41ff284430d18ca3b6e8116c25d461d98e84d711)
@@ -107,8 +107,8 @@
[workspace.dependencies]
# rust-vmm crates
acpi_tables = { git = "https://github.com/rust-vmm/acpi_tables", branch = "main" }
-kvm-bindings = "0.12.0"
-kvm-ioctls = "0.22.0"
+kvm-bindings = "0.12.1"
+kvm-ioctls = "0.22.1"
# TODO: update to 0.13.1+
linux-loader = { git = "https://github.com/rust-vmm/linux-loader", branch = "main" }
mshv-bindings = "0.6.0"
@@ -153,3 +153,7 @@
uuid = { version = "1.18.1" }
wait-timeout = "0.2.1"
zerocopy = { version = "0.8.26", default-features = false }
+
+[patch.crates-io]
+kvm-bindings = { path = "../kvm-rs/kvm-bindings" }
+kvm-ioctls = { path = "../kvm-rs/kvm-ioctls" }
\ No newline at end of file
Index: hypervisor/src/cpu.rs
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/hypervisor/src/cpu.rs b/hypervisor/src/cpu.rs
--- a/hypervisor/src/cpu.rs	(revision ad9a1878bfb79a9a64607bfa613ae916169e1bc2)
+++ b/hypervisor/src/cpu.rs	(revision 7d1e6ac25b8c1c99d3069c81188d979c75b46e4d)
@@ -13,6 +13,7 @@
#[cfg(target_arch = "aarch64")]
use std::sync::Arc;

+use kvm_bindings::nested::KvmNestedStateBuffer;
use thiserror::Error;
#[cfg(not(target_arch = "riscv64"))]
use vm_memory::GuestAddress;
@@ -334,6 +335,10 @@
///
#[error("Failed to inject NMI")]
Nmi(#[source] anyhow::Error),
+    #[error("Failed to get nested guest state")]
+    GetNestedState(#[source] anyhow::Error),
+    #[error("Failed to set nested guest state")]
+    SetNestedState(#[source] anyhow::Error),
     }

#[derive(Debug)]
@@ -514,6 +519,15 @@
/// This function is necessary to snapshot the VM
///
fn state(&self) -> Result<CpuState>;
+
+    /// Get the state of the nested guest from the current vCPU,
+    /// if there is any.
+    #[cfg(target_arch = "x86_64")]
+    fn nested_state(&self) -> Result<Option<KvmNestedStateBuffer>>;
+
+    /// Sets the state of the nested guest for the current vCPU.
+    #[cfg(target_arch = "x86_64")]
+    fn set_nested_state(&self, state: &KvmNestedStateBuffer) -> Result<()>;
     ///
     /// Set the vCPU state.
     /// This function is required when restoring the VM
     Index: hypervisor/src/kvm/mod.rs
     IDEA additional info:
     Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
     <+>UTF-8
     ===================================================================
     diff --git a/hypervisor/src/kvm/mod.rs b/hypervisor/src/kvm/mod.rs
     --- a/hypervisor/src/kvm/mod.rs	(revision ad9a1878bfb79a9a64607bfa613ae916169e1bc2)
     +++ b/hypervisor/src/kvm/mod.rs	(revision 7d1e6ac25b8c1c99d3069c81188d979c75b46e4d)
     @@ -86,6 +86,7 @@
     ///
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub use kvm_bindings::kvm_vcpu_events as VcpuEvents;
     +use kvm_bindings::nested::KvmNestedStateBuffer;
     pub use kvm_bindings::{
     KVM_GUESTDBG_ENABLE, KVM_GUESTDBG_SINGLESTEP, KVM_IRQ_ROUTING_IRQCHIP, KVM_IRQ_ROUTING_MSI,
     KVM_MEM_LOG_DIRTY_PAGES, KVM_MEM_READONLY, KVM_MSI_VALID_DEVID, kvm_clock_data,
     @@ -2465,6 +2466,7 @@
     let xcrs = self.get_xcrs()?;
     let lapic_state = self.get_lapic()?;
     let fpu = self.get_fpu()?;
+        let nested_state = self.nested_state()?;

         // Try to get all MSRs based on the list previously retrieved from KVM.
         // If the number of MSRs obtained from GET_MSRS is different from the
@@ -2539,6 +2541,7 @@
xcrs,
mp_state,
tsc_khz,
+            nested_state,
         }
         .into())
  }
  @@ -2705,6 +2708,9 @@
  self.set_xcrs(&state.xcrs)?;
  self.set_lapic(&state.lapic_state)?;
  self.set_fpu(&state.fpu)?;
+        if let Some(nested_state) = state.nested_state {
+            self.set_nested_state(&nested_state)?;
+        }

         if let Some(freq) = state.tsc_khz {
             self.set_tsc_khz(freq)?;
@@ -2975,6 +2981,25 @@
Ok(_) => Ok(()),
}
}
+
+    fn nested_state(&self) -> cpu::Result<Option<KvmNestedStateBuffer>> {
+        let mut buffer = KvmNestedStateBuffer::empty();
+
+        self.fd
+            .lock()
+            .unwrap()
+            .get_nested_state(&mut buffer)
+            .map(|size| size.map(|_| buffer))
+            .map_err(|e| cpu::HypervisorCpuError::GetNestedState(e.into()))
+    }
+
+    fn set_nested_state(&self, state: &KvmNestedStateBuffer) -> cpu::Result<()> {
+        self.fd
+            .lock()
+            .unwrap()
+            .set_nested_state(state)
+            .map_err(|e| cpu::HypervisorCpuError::GetNestedState(e.into()))
+    }
     }

impl KvmVcpu {
Index: hypervisor/src/kvm/x86_64/mod.rs
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/hypervisor/src/kvm/x86_64/mod.rs b/hypervisor/src/kvm/x86_64/mod.rs
--- a/hypervisor/src/kvm/x86_64/mod.rs	(revision ad9a1878bfb79a9a64607bfa613ae916169e1bc2)
+++ b/hypervisor/src/kvm/x86_64/mod.rs	(revision 7d1e6ac25b8c1c99d3069c81188d979c75b46e4d)
@@ -8,6 +8,7 @@
//
//

+use kvm_bindings::nested::KvmNestedStateBuffer;
use serde::{Deserialize, Serialize};
///
/// Export generically-named wrappers of kvm-bindings for Unix-based platforms
@@ -75,6 +76,9 @@
pub xcrs: ExtendedControlRegisters,
pub mp_state: MpState,
pub tsc_khz: Option<u32>,
+    // Option to prevent useless 8K (de)serialization when no nested
+    // state exists.
+    pub nested_state: Option<KvmNestedStateBuffer>,
     }

impl From<SegmentRegister> for kvm_segment {
Index: vmm/src/seccomp_filters.rs
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/vmm/src/seccomp_filters.rs b/vmm/src/seccomp_filters.rs
--- a/vmm/src/seccomp_filters.rs	(revision ad9a1878bfb79a9a64607bfa613ae916169e1bc2)
+++ b/vmm/src/seccomp_filters.rs	(revision 7d1e6ac25b8c1c99d3069c81188d979c75b46e4d)
@@ -103,6 +103,8 @@
pub const KVM_GET_REG_LIST: u64 = 0xc008_aeb0;
pub const KVM_MEMORY_ENCRYPT_OP: u64 = 0xc008_aeba;
pub const KVM_NMI: u64 = 0xae9a;
+    pub const KVM_GET_NESTED_STATE: u64 = 3229658814;
+    pub const KVM_SET_NESTED_STATE: u64 = 1082175167;
     }

// MSHV IOCTL code. This is unstable until the kernel code has been declared stable.
@@ -232,6 +234,8 @@
and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_USER_MEMORY_REGION,)?],
and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_VCPU_EVENTS,)?],
and![Cond::new(1, ArgLen::Dword, Eq, KVM_NMI)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, KVM_GET_NESTED_STATE)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_NESTED_STATE)?],
  ])
  }

@@ -697,6 +701,8 @@
and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_USER_MEMORY_REGION,)?],
and![Cond::new(1, ArgLen::Dword, Eq, KVM_RUN,)?],
and![Cond::new(1, ArgLen::Dword, Eq, KVM_NMI)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, KVM_GET_NESTED_STATE)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_NESTED_STATE)?],
  ])
  }
```

</details>

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
