### PR TITLE
treewide: cleanup of "extern crate"

### DIFF
--- a/kvm-bindings/src/arm64/fam_wrappers.rs
+++ b/kvm-bindings/src/arm64/fam_wrappers.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use vmm_sys_util::fam::{FamStruct, FamStructWrapper};
+use vmm_sys_util::generate_fam_struct_impl;
 
 use super::bindings::*;
 

--- a/kvm-bindings/src/lib.rs
+++ b/kvm-bindings/src/lib.rs
@@ -9,18 +9,6 @@
 #![deny(clippy::undocumented_unsafe_blocks)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-#[cfg(feature = "fam-wrappers")]
-#[macro_use]
-extern crate vmm_sys_util;
-
-#[cfg(feature = "serde")]
-extern crate serde;
-
-#[cfg(feature = "serde")]
-extern crate zerocopy;
-
-extern crate core;
-
 #[cfg(feature = "serde")]
 #[macro_use]
 mod serialize;

--- a/kvm-bindings/src/riscv64/fam_wrappers.rs
+++ b/kvm-bindings/src/riscv64/fam_wrappers.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use vmm_sys_util::fam::{FamStruct, FamStructWrapper};
+use vmm_sys_util::generate_fam_struct_impl;
 
 use super::bindings::*;
 

--- a/kvm-bindings/src/x86_64/fam_wrappers.rs
+++ b/kvm-bindings/src/x86_64/fam_wrappers.rs
@@ -1,9 +1,9 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use vmm_sys_util::fam::{FamStruct, FamStructWrapper};
-
 use super::bindings::*;
+use vmm_sys_util::fam::{FamStruct, FamStructWrapper};
+use vmm_sys_util::generate_fam_struct_impl;
 
 /// Maximum number of CPUID entries that can be returned by a call to KVM ioctls.
 ///

--- a/kvm-ioctls/src/ioctls/device.rs
+++ b/kvm-ioctls/src/ioctls/device.rs
@@ -51,8 +51,6 @@ impl DeviceFd {
     /// upstreamed. Disabling VFIO device test for RISC-V at the time being.
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
-    /// # extern crate kvm_bindings;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -124,8 +122,6 @@ impl DeviceFd {
     /// Getting the number of IRQs for a GICv2 device on an aarch64 platform
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
-    /// # extern crate kvm_bindings;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();

--- a/kvm-ioctls/src/ioctls/vcpu.rs
+++ b/kvm-ioctls/src/ioctls/vcpu.rs
@@ -224,7 +224,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -254,8 +253,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
-    /// # extern crate kvm_bindings;
     /// # use kvm_ioctls::Kvm;
     /// # use kvm_bindings::{
     ///    KVM_ARM_VCPU_PMU_V3_CTRL, KVM_ARM_VCPU_PMU_V3_INIT
@@ -296,8 +293,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
-    /// # extern crate kvm_bindings;
     /// # use kvm_ioctls::Kvm;
     /// # use kvm_bindings::{
     ///    KVM_ARM_VCPU_PMU_V3_CTRL, KVM_ARM_VCPU_PMU_V3_INIT
@@ -335,7 +330,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -367,7 +361,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -396,7 +389,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -428,7 +420,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -456,8 +447,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
-    /// # extern crate kvm_bindings;
     /// # use kvm_ioctls::Kvm;
     /// # use kvm_bindings::kvm_fpu;
     /// let kvm = Kvm::new().unwrap();
@@ -492,8 +481,6 @@ impl VcpuFd {
     /// # Example
     ///
     ///  ```rust
-    /// # extern crate kvm_ioctls;
-    /// # extern crate kvm_bindings;
     /// # use kvm_bindings::KVM_MAX_CPUID_ENTRIES;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
@@ -537,8 +524,6 @@ impl VcpuFd {
     /// # Example
     ///
     ///  ```rust
-    /// # extern crate kvm_ioctls;
-    /// # extern crate kvm_bindings;
     /// # use kvm_bindings::KVM_MAX_CPUID_ENTRIES;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
@@ -576,8 +561,6 @@ impl VcpuFd {
     /// # Example
     ///
     ///  ```rust
-    /// # extern crate kvm_ioctls;
-    /// # extern crate kvm_bindings;
     /// # use kvm_bindings::{kvm_enable_cap, KVM_MAX_CPUID_ENTRIES, KVM_CAP_HYPERV_SYNIC, KVM_CAP_SPLIT_IRQCHIP};
     /// # use kvm_ioctls::{Kvm, Cap};
     /// let kvm = Kvm::new().unwrap();
@@ -617,7 +600,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -650,7 +632,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::Kvm;
     /// use std::io::Write;
     ///
@@ -695,8 +676,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
-    /// # extern crate kvm_bindings;
     /// # use kvm_ioctls::Kvm;
     /// # use kvm_bindings::{kvm_msr_entry, Msrs};
     /// let kvm = Kvm::new().unwrap();
@@ -739,8 +718,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
-    /// # extern crate kvm_bindings;
     /// # use kvm_ioctls::Kvm;
     /// # use kvm_bindings::{kvm_msr_entry, Msrs};
     /// let kvm = Kvm::new().unwrap();
@@ -779,7 +756,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -814,7 +790,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -850,7 +825,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -896,8 +870,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
-    /// # extern crate kvm_bindings;
     /// # extern crate vmm_sys_util;
     /// # use kvm_ioctls::{Kvm, Cap};
     /// # use kvm_bindings::{Xsave, kvm_xsave, kvm_xsave2};
@@ -960,7 +932,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -1004,8 +975,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
-    /// # extern crate kvm_bindings;
     /// # extern crate vmm_sys_util;
     /// # use kvm_ioctls::{Kvm, Cap};
     /// # use kvm_bindings::{Xsave, kvm_xsave, kvm_xsave2};
@@ -1040,7 +1009,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -1070,7 +1038,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -1101,7 +1068,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -1131,7 +1097,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -1163,7 +1128,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::{Kvm, Cap};
     /// let kvm = Kvm::new().unwrap();
     /// if kvm.check_extension(Cap::VcpuEvents) {
@@ -1195,7 +1159,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::{Kvm, Cap};
     /// let kvm = Kvm::new().unwrap();
     /// if kvm.check_extension(Cap::VcpuEvents) {
@@ -1230,8 +1193,6 @@ impl VcpuFd {
     ///
     /// # Example
     /// ```rust
-    /// # extern crate kvm_ioctls;
-    /// # extern crate kvm_bindings;
     /// # use kvm_ioctls::Kvm;
     /// use kvm_bindings::kvm_vcpu_init;
     /// let kvm = Kvm::new().unwrap();
@@ -1279,8 +1240,6 @@ impl VcpuFd {
     ///
     /// # Example
     /// ```rust
-    /// # extern crate kvm_ioctls;
-    /// # extern crate kvm_bindings;
     /// # use kvm_ioctls::Kvm;
     /// use std::arch::is_aarch64_feature_detected;
     ///
@@ -1321,8 +1280,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
-    /// # extern crate kvm_bindings;
     /// # use kvm_ioctls::Kvm;
     /// # use kvm_bindings::RegList;
     /// let kvm = Kvm::new().unwrap();
@@ -1365,8 +1322,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
-    /// # extern crate kvm_bindings;
     /// # use kvm_ioctls::Kvm;
     /// # use kvm_bindings::{
     /// #     KVM_GUESTDBG_ENABLE, KVM_GUESTDBG_USE_SW_BP, kvm_guest_debug_arch, kvm_guest_debug
@@ -1491,8 +1446,6 @@ impl VcpuFd {
     /// [https://lwn.net/Articles/658511/](https://lwn.net/Articles/658511/).
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
-    /// # extern crate kvm_bindings;
     /// # use std::io::Write;
     /// # use std::ptr::null_mut;
     /// # use std::slice;
@@ -1734,7 +1687,6 @@ impl VcpuFd {
     /// # Example
     ///
     ///  ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -1764,7 +1716,6 @@ impl VcpuFd {
     /// # Example
     ///
     ///  ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::{Cap, Kvm};
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -1799,7 +1750,6 @@ impl VcpuFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -1832,7 +1782,6 @@ impl VcpuFd {
     /// # Example
     ///
     ///  ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::{Kvm, SyncReg, Cap};
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -1856,7 +1805,6 @@ impl VcpuFd {
     /// # Example
     ///
     ///  ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::{Kvm, SyncReg, Cap};
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -1878,7 +1826,6 @@ impl VcpuFd {
     /// # Example
     ///
     ///  ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::{Kvm, SyncReg, Cap};
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -1900,7 +1847,6 @@ impl VcpuFd {
     /// # Example
     ///
     ///  ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::{Kvm, SyncReg, Cap};
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -1918,7 +1864,6 @@ impl VcpuFd {
     /// # Example
     ///
     ///  ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::{Kvm, SyncReg, Cap};
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -1944,7 +1889,6 @@ impl VcpuFd {
     /// # Example
     ///
     ///  ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::{Kvm, SyncReg, Cap};
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
@@ -2176,7 +2120,6 @@ impl AsRawFd for VcpuFd {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::undocumented_unsafe_blocks)]
-    extern crate byteorder;
 
     use super::*;
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
@@ -2348,7 +2291,7 @@ mod tests {
     fn lapic_test() {
         use std::io::Cursor;
         // We might get read of byteorder if we replace mem::transmute with something safer.
-        use self::byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+        use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
         // As per https://github.com/torvalds/linux/arch/x86/kvm/lapic.c
         // Try to write and read the APIC_ICR (0x300) register which is non-read only and
         // one can simply write to it.

--- a/kvm-ioctls/src/ioctls/vm.rs
+++ b/kvm-ioctls/src/ioctls/vm.rs
@@ -84,9 +84,6 @@ impl VmFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
-    /// extern crate kvm_bindings;
-    ///
     /// use kvm_bindings::kvm_userspace_memory_region;
     /// use kvm_ioctls::Kvm;
     ///
@@ -142,10 +139,7 @@ impl VmFd {
     ///
     /// On x86, create a `KVM_X86_SW_PROTECTED_VM` with a memslot that has a `guest_memfd` associated.
     ///
-    /// ```rust
-    /// # extern crate kvm_ioctls;
-    /// extern crate kvm_bindings;
-    ///
+    /// ```rust///
     /// use kvm_bindings::{
     ///     KVM_CAP_GUEST_MEMFD, KVM_CAP_USER_MEMORY2, KVM_MEM_GUEST_MEMFD, kvm_create_guest_memfd,
     ///     kvm_userspace_memory_region2,
@@ -244,7 +238,6 @@ impl VmFd {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate kvm_ioctls;
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();

--- a/kvm-ioctls/src/kvm_ioctls.rs
+++ b/kvm-ioctls/src/kvm_ioctls.rs
@@ -8,6 +8,7 @@
 //! Declares necessary ioctls specific to their platform.
 
 use kvm_bindings::*;
+use vmm_sys_util::{ioctl_io_nr, ioctl_ior_nr, ioctl_iow_nr, ioctl_iowr_nr};
 
 // Ioctls for /dev/kvm.
 

--- a/kvm-ioctls/src/lib.rs
+++ b/kvm-ioctls/src/lib.rs
@@ -55,9 +55,6 @@
 //!
 //!
 //! ```rust
-//! extern crate kvm_ioctls;
-//! extern crate kvm_bindings;
-//!
 //! use kvm_ioctls::VcpuExit;
 //! use kvm_ioctls::{Kvm, VcpuFd, VmFd};
 //!
@@ -231,11 +228,6 @@
 //!     }
 //! }
 //! ```
-
-extern crate kvm_bindings;
-extern crate libc;
-#[macro_use]
-extern crate vmm_sys_util;
 
 #[macro_use]
 mod kvm_ioctls;

--- a/kvm-ioctls/src/lib.rs
+++ b/kvm-ioctls/src/lib.rs
@@ -58,173 +58,171 @@
 //! use kvm_ioctls::VcpuExit;
 //! use kvm_ioctls::{Kvm, VcpuFd, VmFd};
 //!
-//! fn main() {
-//!     use std::io::Write;
-//!     use std::ptr::null_mut;
-//!     use std::slice;
+//! use std::io::Write;
+//! use std::ptr::null_mut;
+//! use std::slice;
 //!
-//!     use kvm_bindings::KVM_MEM_LOG_DIRTY_PAGES;
-//!     use kvm_bindings::kvm_userspace_memory_region;
+//! use kvm_bindings::KVM_MEM_LOG_DIRTY_PAGES;
+//! use kvm_bindings::kvm_userspace_memory_region;
 //!
-//!     let mem_size = 0x4000;
-//!     let guest_addr = 0x1000;
-//!     let asm_code: &[u8];
+//! let mem_size = 0x4000;
+//! let guest_addr = 0x1000;
+//! let asm_code: &[u8];
 //!
-//!     // Setting up architectural dependent values.
-//!     #[cfg(target_arch = "x86_64")]
-//!     {
-//!         asm_code = &[
-//!             0xba, 0xf8, 0x03, /* mov $0x3f8, %dx */
-//!             0x00, 0xd8, /* add %bl, %al */
-//!             0x04, b'0', /* add $'0', %al */
-//!             0xee, /* out %al, %dx */
-//!             0xec, /* in %dx, %al */
-//!             0xc6, 0x06, 0x00, 0x80,
-//!             0x00, /* movl $0, (0x8000); This generates a MMIO Write. */
-//!             0x8a, 0x16, 0x00, 0x80, /* movl (0x8000), %dl; This generates a MMIO Read. */
-//!             0xf4, /* hlt */
-//!         ];
-//!     }
-//!     #[cfg(target_arch = "aarch64")]
-//!     {
-//!         asm_code = &[
-//!             0x01, 0x00, 0x00, 0x10, /* adr x1, <this address> */
-//!             0x22, 0x10, 0x00, 0xb9, /* str w2, [x1, #16]; write to this page */
-//!             0x02, 0x00, 0x00, 0xb9, /* str w2, [x0]; This generates a MMIO Write. */
-//!             0x00, 0x00, 0x00,
-//!             0x14, /* b <this address>; shouldn't get here, but if so loop forever */
-//!         ];
-//!     }
-//!     #[cfg(target_arch = "riscv64")]
-//!     {
-//!         asm_code = &[
-//!             0x17, 0x03, 0x00, 0x00, // auipc t1, 0;     <this address> -> t1
-//!             0xa3, 0x23, 0x73, 0x00, // sw t2, t1 + 7;   dirty current page
-//!             0x23, 0x20, 0x75, 0x00, // sw t2, a0;       trigger MMIO exit
-//!             0x6f, 0x00, 0x00, 0x00, // j .;shouldn't get here, but if so loop forever
-//!         ];
-//!     }
+//! // Setting up architectural dependent values.
+//! #[cfg(target_arch = "x86_64")]
+//! {
+//!     asm_code = &[
+//!         0xba, 0xf8, 0x03, /* mov $0x3f8, %dx */
+//!         0x00, 0xd8, /* add %bl, %al */
+//!         0x04, b'0', /* add $'0', %al */
+//!         0xee, /* out %al, %dx */
+//!         0xec, /* in %dx, %al */
+//!         0xc6, 0x06, 0x00, 0x80,
+//!         0x00, /* movl $0, (0x8000); This generates a MMIO Write. */
+//!         0x8a, 0x16, 0x00, 0x80, /* movl (0x8000), %dl; This generates a MMIO Read. */
+//!         0xf4, /* hlt */
+//!     ];
+//! }
+//! #[cfg(target_arch = "aarch64")]
+//! {
+//!     asm_code = &[
+//!         0x01, 0x00, 0x00, 0x10, /* adr x1, <this address> */
+//!         0x22, 0x10, 0x00, 0xb9, /* str w2, [x1, #16]; write to this page */
+//!         0x02, 0x00, 0x00, 0xb9, /* str w2, [x0]; This generates a MMIO Write. */
+//!         0x00, 0x00, 0x00,
+//!         0x14, /* b <this address>; shouldn't get here, but if so loop forever */
+//!     ];
+//! }
+//! #[cfg(target_arch = "riscv64")]
+//! {
+//!     asm_code = &[
+//!         0x17, 0x03, 0x00, 0x00, // auipc t1, 0;     <this address> -> t1
+//!         0xa3, 0x23, 0x73, 0x00, // sw t2, t1 + 7;   dirty current page
+//!         0x23, 0x20, 0x75, 0x00, // sw t2, a0;       trigger MMIO exit
+//!         0x6f, 0x00, 0x00, 0x00, // j .;shouldn't get here, but if so loop forever
+//!     ];
+//! }
 //!
-//!     // 1. Instantiate KVM.
-//!     let kvm = Kvm::new().unwrap();
+//! // 1. Instantiate KVM.
+//! let kvm = Kvm::new().unwrap();
 //!
-//!     // 2. Create a VM.
-//!     let vm = kvm.create_vm().unwrap();
+//! // 2. Create a VM.
+//! let vm = kvm.create_vm().unwrap();
 //!
-//!     // 3. Initialize Guest Memory.
-//!     let load_addr: *mut u8 = unsafe {
-//!         libc::mmap(
-//!             null_mut(),
-//!             mem_size,
-//!             libc::PROT_READ | libc::PROT_WRITE,
-//!             libc::MAP_ANONYMOUS | libc::MAP_SHARED | libc::MAP_NORESERVE,
-//!             -1,
-//!             0,
-//!         ) as *mut u8
-//!     };
+//! // 3. Initialize Guest Memory.
+//! let load_addr: *mut u8 = unsafe {
+//!     libc::mmap(
+//!         null_mut(),
+//!         mem_size,
+//!         libc::PROT_READ | libc::PROT_WRITE,
+//!         libc::MAP_ANONYMOUS | libc::MAP_SHARED | libc::MAP_NORESERVE,
+//!         -1,
+//!         0,
+//!     ) as *mut u8
+//! };
 //!
-//!     let slot = 0;
-//!     // When initializing the guest memory slot specify the
-//!     // `KVM_MEM_LOG_DIRTY_PAGES` to enable the dirty log.
-//!     let mem_region = kvm_userspace_memory_region {
-//!         slot,
-//!         guest_phys_addr: guest_addr,
-//!         memory_size: mem_size as u64,
-//!         userspace_addr: load_addr as u64,
-//!         flags: KVM_MEM_LOG_DIRTY_PAGES,
-//!     };
-//!     unsafe { vm.set_user_memory_region(mem_region).unwrap() };
+//! let slot = 0;
+//! // When initializing the guest memory slot specify the
+//! // `KVM_MEM_LOG_DIRTY_PAGES` to enable the dirty log.
+//! let mem_region = kvm_userspace_memory_region {
+//!     slot,
+//!     guest_phys_addr: guest_addr,
+//!     memory_size: mem_size as u64,
+//!     userspace_addr: load_addr as u64,
+//!     flags: KVM_MEM_LOG_DIRTY_PAGES,
+//! };
+//! unsafe { vm.set_user_memory_region(mem_region).unwrap() };
 //!
-//!     // Write the code in the guest memory. This will generate a dirty page.
-//!     unsafe {
-//!         let mut slice = slice::from_raw_parts_mut(load_addr, mem_size);
-//!         slice.write(&asm_code).unwrap();
-//!     }
+//! // Write the code in the guest memory. This will generate a dirty page.
+//! unsafe {
+//!     let mut slice = slice::from_raw_parts_mut(load_addr, mem_size);
+//!     slice.write(&asm_code).unwrap();
+//! }
 //!
-//!     // 4. Create one vCPU.
-//!     let mut vcpu_fd = vm.create_vcpu(0).unwrap();
+//! // 4. Create one vCPU.
+//! let mut vcpu_fd = vm.create_vcpu(0).unwrap();
 //!
-//!     // 5. Initialize general purpose and special registers.
-//!     #[cfg(target_arch = "x86_64")]
-//!     {
-//!         // x86_64 specific registry setup.
-//!         let mut vcpu_sregs = vcpu_fd.get_sregs().unwrap();
-//!         vcpu_sregs.cs.base = 0;
-//!         vcpu_sregs.cs.selector = 0;
-//!         vcpu_fd.set_sregs(&vcpu_sregs).unwrap();
+//! // 5. Initialize general purpose and special registers.
+//! #[cfg(target_arch = "x86_64")]
+//! {
+//!     // x86_64 specific registry setup.
+//!     let mut vcpu_sregs = vcpu_fd.get_sregs().unwrap();
+//!     vcpu_sregs.cs.base = 0;
+//!     vcpu_sregs.cs.selector = 0;
+//!     vcpu_fd.set_sregs(&vcpu_sregs).unwrap();
 //!
-//!         let mut vcpu_regs = vcpu_fd.get_regs().unwrap();
-//!         vcpu_regs.rip = guest_addr;
-//!         vcpu_regs.rax = 2;
-//!         vcpu_regs.rbx = 3;
-//!         vcpu_regs.rflags = 2;
-//!         vcpu_fd.set_regs(&vcpu_regs).unwrap();
-//!     }
+//!     let mut vcpu_regs = vcpu_fd.get_regs().unwrap();
+//!     vcpu_regs.rip = guest_addr;
+//!     vcpu_regs.rax = 2;
+//!     vcpu_regs.rbx = 3;
+//!     vcpu_regs.rflags = 2;
+//!     vcpu_fd.set_regs(&vcpu_regs).unwrap();
+//! }
 //!
-//!     #[cfg(target_arch = "aarch64")]
-//!     {
-//!         // aarch64 specific registry setup.
-//!         let mut kvi = kvm_bindings::kvm_vcpu_init::default();
-//!         vm.get_preferred_target(&mut kvi).unwrap();
-//!         vcpu_fd.vcpu_init(&kvi).unwrap();
+//! #[cfg(target_arch = "aarch64")]
+//! {
+//!     // aarch64 specific registry setup.
+//!     let mut kvi = kvm_bindings::kvm_vcpu_init::default();
+//!     vm.get_preferred_target(&mut kvi).unwrap();
+//!     vcpu_fd.vcpu_init(&kvi).unwrap();
 //!
-//!         let core_reg_base: u64 = 0x6030_0000_0010_0000;
-//!         let mmio_addr: u64 = guest_addr + mem_size as u64;
-//!         // set PC
-//!         vcpu_fd.set_one_reg(core_reg_base + 2 * 32, &guest_addr.to_le_bytes());
-//!         // set X0
-//!         vcpu_fd.set_one_reg(core_reg_base + 2 * 0, &mmio_addr.to_le_bytes());
-//!     }
+//!     let core_reg_base: u64 = 0x6030_0000_0010_0000;
+//!     let mmio_addr: u64 = guest_addr + mem_size as u64;
+//!     // set PC
+//!     vcpu_fd.set_one_reg(core_reg_base + 2 * 32, &guest_addr.to_le_bytes());
+//!     // set X0
+//!     vcpu_fd.set_one_reg(core_reg_base + 2 * 0, &mmio_addr.to_le_bytes());
+//! }
 //!
-//!     #[cfg(target_arch = "riscv64")]
-//!     {
-//!         // riscv64 specific register setup.
-//!         let core_reg_base: u64 = 0x8030_0000_0200_0000;
-//!         let mmio_addr: u64 = guest_addr + mem_size as u64;
-//!         // set PC
-//!         vcpu_fd.set_one_reg(core_reg_base, &guest_addr.to_le_bytes());
-//!         // set A0
-//!         vcpu_fd.set_one_reg(core_reg_base + 10, &mmio_addr.to_le_bytes());
-//!     }
+//! #[cfg(target_arch = "riscv64")]
+//! {
+//!     // riscv64 specific register setup.
+//!     let core_reg_base: u64 = 0x8030_0000_0200_0000;
+//!     let mmio_addr: u64 = guest_addr + mem_size as u64;
+//!     // set PC
+//!     vcpu_fd.set_one_reg(core_reg_base, &guest_addr.to_le_bytes());
+//!     // set A0
+//!     vcpu_fd.set_one_reg(core_reg_base + 10, &mmio_addr.to_le_bytes());
+//! }
 //!
-//!     // 6. Run code on the vCPU.
-//!     loop {
-//!         match vcpu_fd.run().expect("run failed") {
-//!             VcpuExit::IoIn(addr, data) => {
-//!                 println!(
-//!                     "Received an I/O in exit. Address: {:#x}. Data: {:#x}",
-//!                     addr, data[0],
-//!                 );
-//!             }
-//!             VcpuExit::IoOut(addr, data) => {
-//!                 println!(
-//!                     "Received an I/O out exit. Address: {:#x}. Data: {:#x}",
-//!                     addr, data[0],
-//!                 );
-//!             }
-//!             VcpuExit::MmioRead(addr, data) => {
-//!                 println!("Received an MMIO Read Request for the address {:#x}.", addr,);
-//!             }
-//!             VcpuExit::MmioWrite(addr, data) => {
-//!                 println!("Received an MMIO Write Request to the address {:#x}.", addr,);
-//!                 // The code snippet dirties 1 page when it is loaded in memory
-//!                 let dirty_pages_bitmap = vm.get_dirty_log(slot, mem_size).unwrap();
-//!                 let dirty_pages = dirty_pages_bitmap
-//!                     .into_iter()
-//!                     .map(|page| page.count_ones())
-//!                     .fold(0, |dirty_page_count, i| dirty_page_count + i);
-//!                 assert_eq!(dirty_pages, 1);
-//!                 // Since on aarch64 there is not halt instruction,
-//!                 // we break immediately after the last known instruction
-//!                 // of the asm code example so that we avoid an infinite loop.
-//!                 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-//!                 break;
-//!             }
-//!             VcpuExit::Hlt => {
-//!                 break;
-//!             }
-//!             r => panic!("Unexpected exit reason: {:?}", r),
+//! // 6. Run code on the vCPU.
+//! loop {
+//!     match vcpu_fd.run().expect("run failed") {
+//!         VcpuExit::IoIn(addr, data) => {
+//!             println!(
+//!                 "Received an I/O in exit. Address: {:#x}. Data: {:#x}",
+//!                 addr, data[0],
+//!             );
 //!         }
+//!         VcpuExit::IoOut(addr, data) => {
+//!             println!(
+//!                 "Received an I/O out exit. Address: {:#x}. Data: {:#x}",
+//!                 addr, data[0],
+//!             );
+//!         }
+//!         VcpuExit::MmioRead(addr, data) => {
+//!             println!("Received an MMIO Read Request for the address {:#x}.", addr,);
+//!         }
+//!         VcpuExit::MmioWrite(addr, data) => {
+//!             println!("Received an MMIO Write Request to the address {:#x}.", addr,);
+//!             // The code snippet dirties 1 page when it is loaded in memory
+//!             let dirty_pages_bitmap = vm.get_dirty_log(slot, mem_size).unwrap();
+//!             let dirty_pages = dirty_pages_bitmap
+//!                 .into_iter()
+//!                 .map(|page| page.count_ones())
+//!                 .fold(0, |dirty_page_count, i| dirty_page_count + i);
+//!             assert_eq!(dirty_pages, 1);
+//!             // Since on aarch64 there is not halt instruction,
+//!             // we break immediately after the last known instruction
+//!             // of the asm code example so that we avoid an infinite loop.
+//!             #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+//!             break;
+//!         }
+//!         VcpuExit::Hlt => {
+//!             break;
+//!         }
+//!         r => panic!("Unexpected exit reason: {:?}", r),
 //!     }
 //! }
 //! ```


### PR DESCRIPTION
### Summary of the PR

Treewide cleanup of "extern crate". No longer needed with Rust edition 2024. Using it is an antipattern. The only exception is `extern crate alloc` in `no_std` environments, which we do not have here.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
