### PR TITLE
kvm-ioctls: Fix create device wrapper in v0.12.1 and release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## Fixed
 
-- [[#298](https://github.com/rust-vmm/kvm/pull/298)]: Fixed incorrect usage of `ioctl_wit_ref` in the
-  `create_device` method. Replace it with `ioctl_wit_mut_ref` as the passed parameter may be mutated by the
-  ioctl.
+- [[#298](https://github.com/rust-vmm/kvm/pull/298)]: Fixed incorrect
+  usage of `ioctl_with_ref` in the `create_device` method. Replace it
+  with `ioctl_with_mut_ref` as the passed parameter may be mutated by
+  the ioctl.
 
 # v0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# v0.12.1
+
 ## Fixed
 
 - [[#298](https://github.com/rust-vmm/kvm/pull/298)]: Fixed incorrect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Fixed
+
+- [[#298](https://github.com/rust-vmm/kvm/pull/298)]: Fixed incorrect usage of `ioctl_wit_ref` in the
+  `create_device` method. Replace it with `ioctl_wit_mut_ref` as the passed parameter may be mutated by the
+  ioctl.
+
 # v0.12.0
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvm-ioctls"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Amazon Firecracker Team <firecracker-maintainers@amazon.com>"]
 description = "Safe wrappers over KVM ioctls"
 repository = "https://github.com/rust-vmm/kvm-ioctls"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,10 @@
+[toolchain]
+channel = "1.63.0"
+components = ["rust-src", "rustfmt", "clippy"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-unknown-linux-musl",
+]
+

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -306,6 +306,7 @@ impl VmFd {
     ///
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
+    /// vm.create_irq_chip().unwrap();
     /// let pit_config = kvm_pit_config::default();
     /// vm.create_pit2(pit_config).unwrap();
     /// ```
@@ -339,6 +340,7 @@ impl VmFd {
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
+    /// vm.create_irq_chip().unwrap();
     ///
     /// let pit_config = kvm_pit_config::default();
     /// vm.create_pit2(pit_config).unwrap();
@@ -376,6 +378,7 @@ impl VmFd {
     /// # use kvm_ioctls::Kvm;
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
+    /// vm.create_irq_chip().unwrap();
     ///
     /// let pit_config = kvm_pit_config::default();
     /// vm.create_pit2(pit_config).unwrap();
@@ -1750,6 +1753,9 @@ mod tests {
     fn test_pit2() {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
+        assert!(kvm.check_extension(Cap::Irqchip));
+        assert!(vm.create_irq_chip().is_ok());
+
         assert!(vm.create_pit2(kvm_pit_config::default()).is_ok());
 
         let pit2 = vm.get_pit2().unwrap();

--- a/src/ioctls/vm.rs
+++ b/src/ioctls/vm.rs
@@ -20,9 +20,11 @@ use crate::ioctls::{KvmRunWrapper, Result};
 use crate::kvm_ioctls::*;
 use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::EventFd;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+use vmm_sys_util::ioctl::ioctl;
+#[cfg(target_arch = "x86_64")]
 use vmm_sys_util::ioctl::ioctl_with_mut_ptr;
-use vmm_sys_util::ioctl::{ioctl, ioctl_with_mut_ref, ioctl_with_ref, ioctl_with_val};
+use vmm_sys_util::ioctl::{ioctl_with_mut_ref, ioctl_with_ref, ioctl_with_val};
 
 /// An address either in programmable I/O space or in memory mapped I/O space.
 ///
@@ -1200,7 +1202,7 @@ impl VmFd {
     /// });
     /// ```
     pub fn create_device(&self, device: &mut kvm_create_device) -> Result<DeviceFd> {
-        let ret = unsafe { ioctl_with_ref(self, KVM_CREATE_DEVICE(), device) };
+        let ret = unsafe { ioctl_with_mut_ref(self, KVM_CREATE_DEVICE(), device) };
         if ret == 0 {
             Ok(new_device(unsafe { File::from_raw_fd(device.fd as i32) }))
         } else {


### PR DESCRIPTION
### Summary of the PR

Backport 01cac5e2b1552ec5643dc536c847cd444bb475aa to v0.12.1 to resolve #355.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
