### PR TITLE
fam_wrappers: Remove code snippet of kvm_save2.len

### DIFF
--- a/kvm-bindings/src/x86_64/fam_wrappers.rs
+++ b/kvm-bindings/src/x86_64/fam_wrappers.rs
@@ -132,12 +132,10 @@ pub type MsrList = FamStructWrapper<kvm_msr_list>;
 pub struct kvm_xsave2 {
     /// The length, in units of sizeof::<__u32>(), of the FAM in [`kvm_xsave`].
     ///
-    /// Note that `KVM_CHECK_EXTENSION(KVM_CAP_XSAVE2)` returns the size of the entire
-    /// `kvm_xsave` structure, e.g. the sum of header and FAM. Thus, this `len` field
-    /// is equal to
-    /// ```norun
-    /// (KVM_CHECK_EXTENSION(KVM_CAP_XSAVE2) - sizeof::<kvm_xsave>()).div_ceil(sizeof::<__u32>())
-    /// ```
+    /// Note that `KVM_CHECK_EXTENSION(KVM_CAP_XSAVE2)` returns the size of the
+    /// entire `kvm_xsave` structure, e.g. the sum of header and FAM. Thus, this
+    /// `len` field is equal to
+    /// `(KVM_CHECK_EXTENSION(KVM_CAP_XSAVE2) - sizeof::<kvm_xsave>()).div_ceil(sizeof::<__u32>()`.
     pub len: usize,
     pub xsave: kvm_xsave,
 }


### PR DESCRIPTION
### Summary of the PR

Code snippet for len field of kvm_xsave2 is outdate for a long while, which also fails to compile. Change the code snippet to pseudo code.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
