### PR TITLE
add `VmFd::{g,s}et_tsc_khz`

### DIFF
--- a/kvm-ioctls/CHANGELOG.md
+++ b/kvm-ioctls/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Plumb through KVM_CAP_DIRTY_LOG_RING as DirtyLogRing cap.
 - [[#359]](https://github.com/rust-vmm/kvm/pull/359) Add support for `KVM_SET_MSR_FILTER` vm ioctl on x86_64.
+- [[#363]](https://github.com/rust-vmm/kvm/pull/363) Add support for setting the default TSC frequency.
 
 ## v0.24.0
 

--- a/kvm-ioctls/src/ioctls/vcpu.rs
+++ b/kvm-ioctls/src/ioctls/vcpu.rs
@@ -2999,6 +2999,7 @@ mod tests {
             vcpu.enable_cap(&cap).unwrap();
         }
     }
+
     #[cfg(target_arch = "x86_64")]
     #[test]
     fn test_get_tsc_khz() {

--- a/kvm-ioctls/src/ioctls/vm.rs
+++ b/kvm-ioctls/src/ioctls/vm.rs
@@ -577,6 +577,57 @@ impl VmFd {
         }
     }
 
+    /// Returns the default vCPU TSC frequency in KHz or an error if the host has unstable TSC.
+    ///
+    /// # Example
+    ///
+    ///  ```rust
+    /// # use kvm_ioctls::Kvm;
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// let tsc_khz = vm.get_tsc_khz().unwrap();
+    /// ```
+    #[cfg(target_arch = "x86_64")]
+    pub fn get_tsc_khz(&self) -> Result<u32> {
+        // SAFETY:  Safe because we know that our file is a KVM fd and that the request is one of
+        // the ones defined by kernel.
+        let ret = unsafe { ioctl(self, KVM_GET_TSC_KHZ()) };
+        if ret >= 0 {
+            Ok(ret as u32)
+        } else {
+            Err(errno::Error::new(ret))
+        }
+    }
+
+    /// Sets the default vCPU TSC frequency.
+    ///
+    /// # Arguments
+    ///
+    /// * `freq` - The frequency unit is KHz as per the KVM API documentation
+    ///   for `KVM_SET_TSC_KHZ`.
+    ///
+    /// # Example
+    ///
+    ///  ```rust
+    /// # use kvm_ioctls::{Cap, Kvm};
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// if kvm.check_extension(Cap::GetTscKhz) && kvm.check_extension(Cap::TscControl) {
+    ///     vm.set_tsc_khz(1000).unwrap();
+    /// }
+    /// ```
+    #[cfg(target_arch = "x86_64")]
+    pub fn set_tsc_khz(&self, freq: u32) -> Result<()> {
+        // SAFETY: Safe because we know that our file is a KVM fd and that the request is one of
+        // the ones defined by kernel.
+        let ret = unsafe { ioctl_with_val(self, KVM_SET_TSC_KHZ(), freq as u64) };
+        if ret < 0 {
+            Err(errno::Error::last())
+        } else {
+            Ok(())
+        }
+    }
+
     /// Sets the MSR filter as per the `KVM_X86_SET_MSR_FILTER` ioctl.
     ///
     /// See the documentation for `KVM_X86_SET_MSR_FILTER` in the


### PR DESCRIPTION
### Summary of the PR

We already support `VcpuFd::{g,s}et_tsc_khz`; this PR extends that to VmFd. This value is used as the default for newly created vCPUs.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [X] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [X] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [X] Any newly added `unsafe` code is properly documented.
