### PR TITLE
Add support for KVM_REINJECT_CONTROL ioctl on x86_64

### DIFF
--- a/kvm-ioctls/CHANGELOG.md
+++ b/kvm-ioctls/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Plumb through KVM_CAP_DIRTY_LOG_RING as DirtyLogRing cap.
 - [[#359]](https://github.com/rust-vmm/kvm/pull/359) Add support for `KVM_SET_MSR_FILTER` vm ioctl on x86_64.
+- Add support for `KVM_REINJECT_CONTROL` vm ioctl on x86_64, also a shortcut `disable_pit_reinjection` on `VmFd`. 
 
 ## v0.24.0
 

--- a/kvm-ioctls/src/kvm_ioctls.rs
+++ b/kvm-ioctls/src/kvm_ioctls.rs
@@ -83,6 +83,9 @@ ioctl_iow_nr!(
     target_arch = "riscv64"
 ))]
 ioctl_iow_nr!(KVM_SET_GSI_ROUTING, KVMIO, 0x6a, kvm_irq_routing);
+/* Available with KVM_CAP_REINJECT_CONTROL */
+#[cfg(target_arch = "x86_64")]
+ioctl_io_nr!(KVM_REINJECT_CONTROL, KVMIO, 0x71);
 /* Available with KVM_CAP_IRQFD */
 #[cfg(any(
     target_arch = "x86_64",


### PR DESCRIPTION
This commit introduces support for the `KVM_REINJECT_CONTROL` VM ioctl on x86_64, along with a convenience method `disable_pit_reinjection` on `VmFd` for easier management of PIT reinjection settings.

### Summary of the PR

Enable user to disable PIT reinjection, which accoding to [kernel doc](https://docs.kernel.org/virt/kvm/api.html#kvm-reinject-control) should be always set when possible. 

> pit_reinject = 0 (!reinject mode) is recommended, unless running an old operating system that uses the PIT for timing (e.g. Linux 2.4.x).

This will help fixing containers/libkrun#498

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
