### PR TITLE
CI: Fix lint warnings & arm64 test failures

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,3 @@
+[advisories]
+  # bincode is only used a dev dependency
+  ignore = [ "RUSTSEC-2025-0141" ]

--- a/kvm-bindings/src/lib.rs
+++ b/kvm-bindings/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! Rust FFI bindings to KVM, generated using [bindgen](https://crates.io/crates/bindgen).
 
+#![allow(confusable_idents)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/kvm-ioctls/src/ioctls/vcpu.rs
+++ b/kvm-ioctls/src/ioctls/vcpu.rs
@@ -1133,6 +1133,13 @@ impl VcpuFd {
     /// if kvm.check_extension(Cap::VcpuEvents) {
     ///     let vm = kvm.create_vm().unwrap();
     ///     let vcpu = vm.create_vcpu(0).unwrap();
+    ///     // On arm64, vCPU needs to be initialized before accesing events
+    ///     #[cfg(target_arch = "aarch64")]
+    ///     {
+    ///         let mut kvi = kvm_bindings::kvm_vcpu_init::default();
+    ///         vm.get_preferred_target(&mut kvi).unwrap();
+    ///         vcpu.vcpu_init(&kvi).unwrap();
+    ///     }
     ///     let vcpu_events = vcpu.get_vcpu_events().unwrap();
     /// }
     /// ```
@@ -1164,6 +1171,13 @@ impl VcpuFd {
     /// if kvm.check_extension(Cap::VcpuEvents) {
     ///     let vm = kvm.create_vm().unwrap();
     ///     let vcpu = vm.create_vcpu(0).unwrap();
+    ///     // On arm64, vCPU needs to be initialized before accesing events
+    ///     #[cfg(target_arch = "aarch64")]
+    ///     {
+    ///         let mut kvi = kvm_bindings::kvm_vcpu_init::default();
+    ///         vm.get_preferred_target(&mut kvi).unwrap();
+    ///         vcpu.vcpu_init(&kvi).unwrap();
+    ///     }
     ///     let vcpu_events = Default::default();
     ///     // Your `vcpu_events` manipulation here.
     ///     vcpu.set_vcpu_events(&vcpu_events).unwrap();
@@ -2445,6 +2459,14 @@ mod tests {
         if kvm.check_extension(Cap::VcpuEvents) {
             let vm = kvm.create_vm().unwrap();
             let vcpu = vm.create_vcpu(0).unwrap();
+
+            #[cfg(target_arch = "aarch64")]
+            {
+                let mut kvi = kvm_vcpu_init::default();
+                vm.get_preferred_target(&mut kvi).unwrap();
+                vcpu.vcpu_init(&kvi).unwrap();
+            }
+
             let vcpu_events = vcpu.get_vcpu_events().unwrap();
             vcpu.set_vcpu_events(&vcpu_events).unwrap();
             let other_vcpu_events = vcpu.get_vcpu_events().unwrap();


### PR DESCRIPTION
### Summary of the PR

Fix two issues with CI:
* Ever since commit 0aa1b76fe142 ("KVM: arm64: Prevent access to vCPU events before init") in the Linux kernel, an arm64 vCPU needs to be initialized before events can be accessed. `vcpu_events_test()`, as well as the doctests for `VcpuFd::{g,s}et_vcpu_events()` currently fail because they do not have this initialization, so just add it.
* Disable the `confusable_idents` lint for kvm-bindings, since most code is generated by bindgen and derive macros.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
