### PR TITLE
kvm-bindings: allow confusable_idents

### DIFF
--- a/kvm-bindings/src/lib.rs
+++ b/kvm-bindings/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! Rust FFI bindings to KVM, generated using [bindgen](https://crates.io/crates/bindgen).
 
+#![allow(confusable_idents)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]


### PR DESCRIPTION
### Summary of the PR

Currently, CI is broken due to the following error:

```
  error: found both `ẕ1` and `ẕl` as identifiers, which look alike
      --> kvm-bindings/src/x86_64/bindings.rs:1199:9
       |
    91 |     derive(zerocopy::IntoBytes, zerocopy::Immutable, zerocopy::FromBytes)
       |                                                      ------------------- other identifier used here
  ...
  1199 |     pub l: __u8,
       |         ^ this identifier can be confused with `ẕ1`
       |
       = note: `-D confusable-idents` implied by `-D warnings`
       = help: to override `-D warnings` add `#[allow(confusable_idents)]`
```

This is due to a mixture bindgen-generated code and derive macro-generated code. Since none of this is human generated, just like most of kvm-bindings, turn the lint off for the crate.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
