### PR TITLE
kvm-bindings: raise kvm_irq_routing cap to KVM_MAX_IRQ_ROUTES

### DIFF
--- a/kvm-bindings/CHANGELOG.md
+++ b/kvm-bindings/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Upcoming Release
 
+### Changed
+
+- [[381]](https://github.com/rust-vmm/kvm/pull/381)
+  Raised kvm_irq_routing cap to KVM_MAX_IRQ_ROUTES (4096) matching the
+  kernel
+
 ## v0.14.1
 
 ### Fixed
@@ -21,8 +27,8 @@
 
 ### Added
 
-- [[#322]](https://github.com/rust-vmm/kvm/pull/322)  
-  Foundations for `kvm-ioctls`'s GET_NESTED_STATE and SET_NESTED_STATE 
+- [[#322]](https://github.com/rust-vmm/kvm/pull/322)
+  Foundations for `kvm-ioctls`'s GET_NESTED_STATE and SET_NESTED_STATE
 
 ### Changed
 

--- a/kvm-bindings/src/arm64/fam_wrappers.rs
+++ b/kvm-bindings/src/arm64/fam_wrappers.rs
@@ -30,6 +30,12 @@ impl PartialEq for kvm_reg_list {
 /// [FamStructWrapper](../vmm_sys_util/fam/struct.FamStructWrapper.html).
 pub type RegList = FamStructWrapper<kvm_reg_list>;
 
+/// Maximum number of IRQ routes KVM can accept (`KVM_MAX_IRQ_ROUTES`).
+///
+/// See `include/linux/kvm_host.h`. This is the ceiling the kernel enforces on
+/// `KVM_SET_GSI_ROUTING.
+pub const KVM_MAX_IRQ_ROUTES: usize = 4096;
+
 // Implement the FamStruct trait for kvm_irq_routing
 generate_fam_struct_impl!(
     kvm_irq_routing,
@@ -37,7 +43,7 @@ generate_fam_struct_impl!(
     entries,
     u32,
     nr,
-    1024
+    KVM_MAX_IRQ_ROUTES
 );
 
 // Implement the PartialEq trait for kvm_irq_routing.

--- a/kvm-bindings/src/riscv64/fam_wrappers.rs
+++ b/kvm-bindings/src/riscv64/fam_wrappers.rs
@@ -30,6 +30,12 @@ impl PartialEq for kvm_reg_list {
 /// implemented using [FamStructWrapper](../vmm_sys_util/fam/struct.FamStructWrapper.html).
 pub type RegList = FamStructWrapper<kvm_reg_list>;
 
+/// Maximum number of IRQ routes KVM can accept (`KVM_MAX_IRQ_ROUTES`).
+///
+/// See `include/linux/kvm_host.h`. This is the ceiling the kernel enforces on
+/// `KVM_SET_GSI_ROUTING`.
+pub const KVM_MAX_IRQ_ROUTES: usize = 4096;
+
 // Implement the FamStruct trait for kvm_irq_routing
 generate_fam_struct_impl!(
     kvm_irq_routing,
@@ -37,7 +43,7 @@ generate_fam_struct_impl!(
     entries,
     u32,
     nr,
-    1024
+    KVM_MAX_IRQ_ROUTES
 );
 
 // Implement the PartialEq trait for kvm_irq_routing.

--- a/kvm-bindings/src/x86_64/fam_wrappers.rs
+++ b/kvm-bindings/src/x86_64/fam_wrappers.rs
@@ -74,6 +74,12 @@ impl PartialEq for kvm_msrs {
 /// [FamStructWrapper](../vmm_sys_util/fam/struct.FamStructWrapper.html).
 pub type Msrs = FamStructWrapper<kvm_msrs>;
 
+/// Maximum number of IRQ routes KVM can accept (`KVM_MAX_IRQ_ROUTES`).
+///
+/// See `include/linux/kvm_host.h`. This is the ceiling the kernel enforces on
+/// `KVM_SET_GSI_ROUTING`.
+pub const KVM_MAX_IRQ_ROUTES: usize = 4096;
+
 // Implement the FamStruct trait for kvm_irq_routing
 generate_fam_struct_impl!(
     kvm_irq_routing,
@@ -81,7 +87,7 @@ generate_fam_struct_impl!(
     entries,
     u32,
     nr,
-    1024
+    KVM_MAX_IRQ_ROUTES
 );
 
 // Implement the PartialEq trait for kvm_irq_routing.
@@ -266,5 +272,13 @@ mod tests {
         assert_eq!(wrapper.as_slice().len(), 1);
         assert_eq!(wrapper.as_fam_struct_ref().len(), 1);
         assert_eq!(wrapper.as_fam_struct_ref().nr, 1);
+
+        // The wrapper must accept up to KVM_MAX_IRQ_ROUTES entries (the kernel's
+        // KVM_MAX_IRQ_ROUTES) and reject anything larger. Large VMs with many
+        // passthrough devices legitimately need well over 1024 GSI routes.
+        assert_eq!(kvm_irq_routing::max_len(), KVM_MAX_IRQ_ROUTES);
+        let wrapper = KvmIrqRouting::new(KVM_MAX_IRQ_ROUTES).unwrap();
+        assert_eq!(wrapper.as_slice().len(), KVM_MAX_IRQ_ROUTES);
+        KvmIrqRouting::new(KVM_MAX_IRQ_ROUTES + 1).unwrap_err();
     }
 }


### PR DESCRIPTION
### Summary of the PR

The `kvm_irq_routing` FamStructWrapper hardcoded its max entry count to 1024, below the kernel's KVM_MAX_IRQ_ROUTES (4096). Large VMs with MSI-X-heavy passthrough devices (say NVMe) legitimately need more than 1024 GSI routes, so `from_entries()`/`new()` failed with `SizeLimitExceeded` on tables the kernel would accept.

Add a named `KVM_MAX_IRQ_ROUTES` constant (4096, matching the kernel) and use it for the x86_64, arm64 and riscv64 wrappers.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
