### PR TITLE
Expose VmFd::enable_cap on all architectures

### DIFF
--- a/kvm-ioctls/CHANGELOG.md
+++ b/kvm-ioctls/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Upcoming Release
 
+### Changed
+
+- [[#382]](https://github.com/rust-vmm/kvm/pull/382) `VmFd::enable_cap` and the
+  `KVM_ENABLE_CAP` ioctl definition are now available on all architectures
+  instead of only x86_64, s390x and powerpc. aarch64 needs them to enable
+  `KVM_CAP_ARM_WRITABLE_IMP_ID_REGS` (Linux 6.15), without which writes to the
+  implementation ID registers (for example `MIDR_EL1` through a VMM CPU
+  template) fail with EINVAL.
+
 ## v0.25.0
 
 ### Added

--- a/kvm-ioctls/src/ioctls/vm.rs
+++ b/kvm-ioctls/src/ioctls/vm.rs
@@ -1521,9 +1521,9 @@ impl VmFd {
     /// // Because an IOAPIC supports 24 pins, that's the reason why this test
     /// // picked this number as reference.
     /// cap.args[0] = 24;
+    /// #[cfg(target_arch = "x86_64")]
     /// vm.enable_cap(&cap).unwrap();
     /// ```
-    #[cfg(any(target_arch = "x86_64", target_arch = "s390x", target_arch = "powerpc"))]
     pub fn enable_cap(&self, cap: &kvm_enable_cap) -> Result<()> {
         // SAFETY: The ioctl is safe because we allocated the struct and we know the
         // kernel will write exactly the size of the struct.

--- a/kvm-ioctls/src/kvm_ioctls.rs
+++ b/kvm-ioctls/src/kvm_ioctls.rs
@@ -226,7 +226,6 @@ ioctl_io_nr!(KVM_SET_TSC_KHZ, KVMIO, 0xa2);
 ioctl_io_nr!(KVM_GET_TSC_KHZ, KVMIO, 0xa3);
 
 /* Available with KVM_CAP_ENABLE_CAP */
-#[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
 ioctl_iow_nr!(KVM_ENABLE_CAP, KVMIO, 0xa3, kvm_enable_cap);
 /* Available with KVM_CAP_SIGNAL_MSI */
 #[cfg(any(


### PR DESCRIPTION
## Summary of the PR

The `KVM_ENABLE_CAP` vm ioctl is architecture independent, but both the ioctl definition and `VmFd::enable_cap` were compiled only for x86_64, s390x and powerpc. This PR removes the cfg gates so they are available on every architecture. The doc example is unchanged as rendered; two hidden doctest lines gate the x86 specific call so the example builds and runs cleanly on every architecture.

Motivation: aarch64 now needs the vm level `enable_cap`. Linux 6.15 gates writes to the implementation ID registers (`MIDR_EL1`, `REVIDR_EL1`, `AIDR_EL1`) behind `KVM_CAP_ARM_WRITABLE_IMP_ID_REGS`, which a VMM must enable on the VM before creating any vCPU. Rewriting these registers is how a VMM masks the host CPU identity for guests (the reason the capability exists in KVM), and without `enable_cap` a VMM has to issue the raw ioctl itself, as Firecracker currently does in firecracker-microvm/firecracker#6116.

Verified: builds and passes clippy and rustfmt on aarch64. The doc example compiles for aarch64 and skips the x86 specific call at runtime; on hosts without `/dev/kvm` it fails the same way as every other doctest in the crate, so CI coverage is unchanged. The underlying ioctl path (enable the capability, then successfully write `MIDR_EL1` via `KVM_SET_ONE_REG`) was exercised end to end on an EC2 c7g.metal running a 7.0 kernel as part of the Firecracker work linked above.

## Requirements

Before submitting your PR, please make sure you addressed the following requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with `git commit -s`), and the commit message has max 60 characters for the summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration test. (Covered by the existing doc example, which now compiles and runs on every architecture.)
- [x] All added/changed public-facing functionality has entries in the "Upcoming Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented. (No new unsafe.)
