### PR TITLE
Use cross-platform capability in enable_cap example

### DIFF
--- a/kvm-ioctls/src/ioctls/vm.rs
+++ b/kvm-ioctls/src/ioctls/vm.rs
@@ -1503,26 +1503,21 @@ impl VmFd {
     /// extern crate kvm_bindings;
     ///
     /// # use kvm_ioctls::Kvm;
-    /// use kvm_bindings::{KVM_CAP_SPLIT_IRQCHIP, kvm_enable_cap};
+    /// use kvm_bindings::{KVM_CAP_HALT_POLL, kvm_enable_cap};
     ///
     /// let kvm = Kvm::new().unwrap();
     /// let vm = kvm.create_vm().unwrap();
-    /// let mut cap: kvm_enable_cap = Default::default();
-    /// cap.cap = KVM_CAP_SPLIT_IRQCHIP;
-    /// // As per the KVM documentation, KVM_CAP_SPLIT_IRQCHIP only emulates
-    /// // the local APIC in kernel, expecting that a userspace IOAPIC will
-    /// // be implemented by the VMM.
-    /// // Along with this capability, the user needs to specify the number
-    /// // of pins reserved for the userspace IOAPIC. This number needs to be
-    /// // provided through the first argument of the capability structure, as
-    /// // specified in KVM documentation:
-    /// //     args[0] - number of routes reserved for userspace IOAPICs
-    /// //
-    /// // Because an IOAPIC supports 24 pins, that's the reason why this test
-    /// // picked this number as reference.
-    /// cap.args[0] = 24;
-    /// #[cfg(target_arch = "x86_64")]
-    /// vm.enable_cap(&cap).unwrap();
+    ///
+    /// if kvm.check_extension_raw(KVM_CAP_HALT_POLL.into()) > 0 {
+    ///     let cap = kvm_enable_cap {
+    ///         cap: KVM_CAP_HALT_POLL,
+    ///         // Set the maximum halt-polling time to 100 microseconds.
+    ///         args: [100_000, 0, 0, 0],
+    ///         ..Default::default()
+    ///     };
+    ///
+    ///     vm.enable_cap(&cap).unwrap();
+    /// }
     /// ```
     pub fn enable_cap(&self, cap: &kvm_enable_cap) -> Result<()> {
         // SAFETY: The ioctl is safe because we allocated the struct and we know the


### PR DESCRIPTION
## Summary of the PR

Replace the x86-specific `KVM_CAP_SPLIT_IRQCHIP` capability in the `VmFd::enable_cap` documentation example with `KVM_CAP_HALT_POLL`.

`KVM_CAP_HALT_POLL` is documented as supporting all architectures and is enabled through the VM fd, so the example no longer needs an architecture-specific `cfg`.

Check support with `check_extension_raw` before enabling the capability. This keeps the example compatible with older kernels that may not support `KVM_CAP_HALT_POLL`.

This follows [@andreeaflorescu’s suggestion](https://github.com/rust-vmm/kvm/pull/382#discussion_r3828871929) during the review of #382.

## Testing

- Ran `RUSTDOCFLAGS="-D warnings" cargo doc -p kvm-ioctls --no-deps`.
- Compiled the revised doctest with warnings denied.
- Ran Clippy with warnings denied for aarch64, x86_64 and riscv64.
- Ran the example against KVM on aarch64 and x86_64. Both hosts reported `KVM_CAP_HALT_POLL` as supported and enabled it successfully.
- Ran `cargo fmt --all --check`.
- Ran `git diff --check`.

## Requirements

- [x] All commits in this PR have Signed-Off-By trailers.
- [x] The changed documentation example is compiled as a doctest.
- [x] No changelog entry is required because this does not change the public API or functionality.
- [x] No new `unsafe` code is added.